### PR TITLE
feat: Initial payment orchestrator setup (Chunks 1-7)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -96,7 +96,7 @@ func (o *Orchestrator) Execute(
 			LatencyMs:    latency, // Placeholder latency
 			Details:      map[string]string{"stubbed_result": "success"},
 		}
-		
+
 		// Ensure details map is initialized
 		if stepResult.Details == nil {
 		    stepResult.Details = make(map[string]string)

--- a/internal/planbuilder/planbuilder.go
+++ b/internal/planbuilder/planbuilder.go
@@ -51,7 +51,7 @@ func (b *PlanBuilder) Build(domainCtx context.DomainContext, extReq *orchestrato
 		Metadata:     make(map[string]string), // Initialize metadata map
 		ProviderPayload: make(map[string]string), // Initialize provider payload map
 	}
-	
+
 	// Ensure metadata and provider_payload are not nil, even if empty
 	if rawStep.Metadata == nil {
 	    rawStep.Metadata = make(map[string]string)
@@ -71,7 +71,7 @@ func (b *PlanBuilder) Build(domainCtx context.DomainContext, extReq *orchestrato
 	if err != nil {
 		return nil, fmt.Errorf("failed to optimize payment plan: %w", err)
 	}
-	
+
 	// Ensure steps are not nil after optimization
 	if optimizedPlan != nil && optimizedPlan.Steps != nil {
 	    for _, step := range optimizedPlan.Steps {

--- a/internal/planbuilder/planbuilder_test.go
+++ b/internal/planbuilder/planbuilder_test.go
@@ -96,7 +96,7 @@ func TestPlanBuilder_Build_NilExternalRequest(t *testing.T) {
 	repo := NewTestMerchantConfigRepository()
 	mockCompositeSvc := &MockCompositePaymentService{}
 	pb := NewPlanBuilder(repo, mockCompositeSvc)
-	
+
 	merchantCfg, _ := repo.Get("merchant123")
 	domainCtx := context.DomainContext{
 		MerchantID:           "merchant123",

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -41,7 +41,7 @@ func (ppe *PaymentPolicyEnforcer) Evaluate(
 	// step *internalv1.PaymentStep, // Placeholder for actual payment step
 	stepCtx context.StepExecutionContext,
 ) (PolicyDecision, error) {
-	
+
 	// Basic stub: always allow retry, don't skip fallback, don't escalate.
 	return PolicyDecision{
 		AllowRetry:     true,

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -21,7 +21,7 @@ func TestPaymentPolicyEnforcer_Evaluate_Stub(t *testing.T) {
 	domainCtx := context.DomainContext{
 		MerchantID: "test-merchant",
 	}
-	
+
 	// Create a dummy PaymentStep if it were used by the Evaluate method.
 	// For the current stub, it's not, but good to have for future.
 	// dummyStep := &internalv1.PaymentStep{ /* ... fields ... */ }


### PR DESCRIPTION
I've implemented the initial structure and core components for the payment orchestrator based on todo.md and spec2_1.md.

Here's what I've completed:

*   **Chunk 1: Project & CI Setup:**
    *   I initialized the Go module (`github.com/yourorg/payment-orchestrator`).
    *   I created the basic directory structure (`cmd`, `internal`, `pkg`, `protos`).
    *   I added a Makefile with `gen`, `lint`, `test` targets.
    *   I added a GitHub Actions CI workflow (`.github/workflows/ci.yml`).

*   **Chunk 2: Schema Definition & Code Generation:**
    *   I defined the Protobuf schemas:
        *   `protos/orchestratorexternalv1/external_request.proto`
        *   `protos/orchestratorinternalv1/payment_plan.proto`
        *   `protos/orchestratorinternalv1/payment_step.proto`
        *   `protos/orchestratorinternalv1/step_result.proto`
    *   I configured `buf.yaml` and `buf.gen.yaml` (using `paths=source_relative`).
    *   I successfully generated Go code from schemas into `pkg/gen/protos/...`.

*   **Chunk 3: Context & Dual Boundary:**
    *   I implemented `TraceContext`, `DomainContext`, `StepExecutionContext`.
    *   I implemented `ContextBuilder` with an `InMemoryMerchantConfigRepository`.
    *   I added comprehensive unit tests for the context package.

*   **Chunk 4: PlanBuilder (Basic) & Composite Stub:**
    *   I created a basic `PlanBuilder` that generates a single-step plan.
    *   I implemented a stub `CompositePaymentService` (returns plan as is).
    *   I resolved significant Go module and Protobuf import path issues by restructuring proto source directories from `schemas/...` to `protos/...` to avoid Go's "internal package use not allowed" error.
    *   Unit tests for `planbuilder` are passing.

*   **Chunk 5: PaymentPolicyEnforcer (Basic):**
    *   I implemented a stub `PaymentPolicyEnforcer` with a default `Evaluate` method.
    *   I added unit tests for the basic policy enforcer.

*   **Chunk 6: Orchestrator (Placeholder ExecuteStep):**
    *   I created a skeleton `Orchestrator` with a placeholder `Execute` method.
    *   The `Orchestrator` uses the policy enforcer and can handle basic plan structures (empty plans, nil steps).
    *   Unit tests for the orchestrator are passing.

*   **Chunk 7: ProviderAdapter Interface & Mock Adapter:**
    *   I defined the `ProviderAdapter` interface (`Process`, `GetName`).
    *   I implemented a `MockAdapter` for testing purposes.
    *   I added unit tests for the mock adapter.

The project now has a foundational structure with key interfaces and stubs in place. Critical build and module resolution issues related to Protobuf generation have been overcome. Next, I decided to tackle the implementation of Chunk 8: Processor Layer.