### PR TITLE
feat: Implement Chunk 11 - StripeAdapter (Simple)

### DIFF
--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -23,6 +23,7 @@ type ProviderResult struct {
 	TransactionID string            // Transaction ID from the provider, if successful
 	LatencyMs     int64             // Latency of the call to the provider
 	RawResponse   []byte            // Raw response body from the provider (for debugging/logging)
+	HTTPStatus    int               // HTTP status code from the provider's response
 	Details       map[string]string // Any other relevant details from the provider
 }
 

--- a/internal/adapter/stripe/stripe_adapter.go
+++ b/internal/adapter/stripe/stripe_adapter.go
@@ -1,0 +1,318 @@
+package stripe
+
+import (
+	// "bytes" // No longer used
+	stdcontext "context" // Standard Go context, aliased to avoid collision
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/yourorg/payment-orchestrator/internal/adapter"
+	"github.com/yourorg/payment-orchestrator/internal/context" // For our custom TraceContext, StepExecutionContext
+	orchestratorinternalv1 "github.com/yourorg/payment-orchestrator/pkg/gen/protos/orchestratorinternalv1"
+)
+
+// StripeAdapter handles communication with the Stripe API.
+type StripeAdapter struct {
+	httpClient *http.Client
+	apiKey     string
+	endpoint   string // e.g., "https://api.stripe.com/v1/payment_intents"
+}
+
+// NewStripeAdapter creates a new instance of StripeAdapter.
+func NewStripeAdapter(client *http.Client, apiKey string, apiEndpoint string) *StripeAdapter {
+	if client == nil {
+		client = &http.Client{}
+	}
+	if apiEndpoint == "" {
+		apiEndpoint = "https://api.stripe.com/v1/payment_intents"
+	}
+	if apiKey == "" {
+		log.Println("StripeAdapter: Warning - API key is empty.") // Or panic, depending on desired strictness
+	}
+	return &StripeAdapter{
+		httpClient: client,
+		apiKey:     apiKey,
+		endpoint:   apiEndpoint,
+	}
+}
+
+// generateIdempotencyKey creates a unique key for Stripe idempotency.
+func (sa *StripeAdapter) generateIdempotencyKey() string {
+	return uuid.NewString()
+}
+
+// buildStripePayload creates an io.Reader for the x-www-form-urlencoded Stripe request body.
+func (sa *StripeAdapter) buildStripePayload(step *orchestratorinternalv1.PaymentStep) (io.Reader, error) {
+	if step == nil {
+		return nil, fmt.Errorf("stripe: payment step cannot be nil")
+	}
+	if step.GetAmount() <= 0 {
+		return nil, fmt.Errorf("stripe: payment amount must be positive, got %d", step.GetAmount())
+	}
+	if step.GetCurrency() == "" {
+		return nil, fmt.Errorf("stripe: currency code cannot be empty")
+	}
+
+	data := url.Values{}
+	data.Set("amount", fmt.Sprintf("%d", step.GetAmount()))
+	data.Set("currency", strings.ToLower(step.GetCurrency()))
+	data.Set("payment_method_types[]", "card")
+
+	if desc, ok := step.GetMetadata()["description"]; ok {
+		data.Set("description", desc)
+	}
+	if sd, ok := step.GetMetadata()["statement_descriptor"]; ok {
+		data.Set("statement_descriptor", sd)
+	}
+	if customerID, ok := step.GetProviderPayload()["stripe_customer_id"]; ok {
+		data.Set("customer", customerID)
+	}
+	if paymentMethodID, ok := step.GetProviderPayload()["stripe_payment_method_id"]; ok {
+		data.Set("payment_method", paymentMethodID)
+		// data.Set("confirm", "true") // Auto-confirm if payment_method is provided; consider if this is always desired
+	}
+	return strings.NewReader(data.Encode()), nil
+}
+
+// --- Stripe API Response Structs ---
+type StripeError struct {
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Type        string `json:"type"`
+	DeclineCode string `json:"decline_code,omitempty"`
+}
+
+type StripeErrorResponse struct {
+	Error StripeError `json:"error"`
+}
+
+type StripePaymentIntent struct {
+	ID                   string            `json:"id"`
+	Amount               int64             `json:"amount"`
+	Currency             string            `json:"currency"`
+	Status               string            `json:"status"`
+	ClientSecret         string            `json:"client_secret,omitempty"`
+	LastPaymentError     *StripeError      `json:"last_payment_error,omitempty"`
+	Metadata             map[string]string `json:"metadata,omitempty"`
+}
+
+// --- Process Method ---
+const MaxRetries = 1 // Exported for test access
+const retryDelay = 500 * time.Millisecond
+
+// Process handles a single payment step using the Stripe provider logic.
+func (sa *StripeAdapter) Process(
+	traceCtx context.TraceContext, // Our custom TraceContext
+	step *orchestratorinternalv1.PaymentStep,
+	stepCtx context.StepExecutionContext, // Our custom StepExecutionContext
+) (adapter.ProviderResult, error) {
+
+	payload, err := sa.buildStripePayload(step)
+	if err != nil {
+		return adapter.ProviderResult{
+			StepID:       step.GetStepId(),
+			Success:      false,
+			ErrorCode:    "PAYLOAD_BUILD_ERROR",
+			ErrorMessage: err.Error(),
+			Provider:     "stripe",
+		}, fmt.Errorf("StripeAdapter.Process: failed to build payload: %w", err)
+	}
+
+	idempotencyKey := sa.generateIdempotencyKey()
+	var lastHttpErr error
+	var httpResp *http.Response
+	var latency time.Duration
+
+	// Use stdcontext.Background() for the HTTP request context for now.
+	// Ideally, a context would be passed down from the initial request, incorporating timeouts/cancellation.
+	// stepCtx.RemainingBudgetMs could be used to create a derived context with timeout.
+	reqCtx := stdcontext.Background()
+	if stepCtx.RemainingBudgetMs > 0 {
+		timeout := time.Duration(stepCtx.RemainingBudgetMs) * time.Millisecond
+		var cancel stdcontext.CancelFunc
+		reqCtx, cancel = stdcontext.WithTimeout(reqCtx, timeout)
+		defer cancel() // Ensure cancel is called to free resources
+	}
+
+
+	for attempt := 0; attempt <= MaxRetries; attempt++ { // Use exported MaxRetries
+		// For retries, the payload might need to be re-created if it's an io.Reader that gets consumed.
+		// strings.NewReader can be read multiple times, but if it were from a one-time stream, care is needed.
+		// For url.Values, data.Encode() can be called again or the string stored.
+		// Since buildStripePayload returns a new strings.NewReader each time, it's fine to call it again if needed,
+		// but for now, we assume the payload reader can be reused or the body is not the cause of retryable errors.
+		// If payload was an `io.ReadCloser` it would be more complex. `strings.NewReader` is fine.
+
+		var currentPayload io.Reader = payload
+		if attempt > 0 { // If retrying, ensure payload can be read again
+		    currentPayload, err = sa.buildStripePayload(step) // Rebuild to be safe for retries
+		    if err != nil {
+		        return adapter.ProviderResult{
+					StepID: step.GetStepId(), Success: false, ErrorCode: "PAYLOAD_REBUILD_ERROR", ErrorMessage: err.Error(), Provider: "stripe"},
+					fmt.Errorf("StripeAdapter.Process: failed to rebuild payload for retry: %w", err)
+			}
+		}
+
+
+		httpReq, err := http.NewRequestWithContext(reqCtx, http.MethodPost, sa.endpoint, currentPayload)
+		if err != nil {
+			// This is a non-retryable error for this attempt, likely fatal for the process.
+			return adapter.ProviderResult{
+				StepID:       step.GetStepId(),
+				Success:      false,
+				ErrorCode:    "REQUEST_CREATION_ERROR",
+				ErrorMessage: err.Error(),
+				Provider:     "stripe",
+			}, fmt.Errorf("StripeAdapter.Process: failed to create http request: %w", err)
+		}
+
+		httpReq.Header.Set("Authorization", "Bearer "+sa.apiKey)
+		httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		httpReq.Header.Set("Idempotency-Key", idempotencyKey)
+		// Consider adding "Stripe-Version" header
+
+		startTime := time.Now()
+		httpResp, err = sa.httpClient.Do(httpReq)
+		latency = time.Since(startTime)
+
+		if err != nil {
+			lastHttpErr = fmt.Errorf("attempt %d: http client error: %w", attempt, err)
+			log.Printf("StripeAdapter.Process: StepID %s, Attempt %d: HTTP client error: %v. Retrying after %v...", step.GetStepId(), attempt, err, retryDelay)
+			if attempt < MaxRetries { // Use exported MaxRetries
+				time.Sleep(retryDelay)
+				continue
+			}
+			break // Max retries reached for this type of error
+		}
+
+		// Successful HTTP request, now check status code
+		if httpResp.StatusCode >= 500 || httpResp.StatusCode == http.StatusTooManyRequests {
+			respBodyBytes, _ := io.ReadAll(httpResp.Body) // Read to log/include in error
+			httpResp.Body.Close() // Close body immediately after read
+
+			lastHttpErr = fmt.Errorf("attempt %d: received HTTP %d: %s", attempt, httpResp.StatusCode, string(respBodyBytes))
+			log.Printf("StripeAdapter.Process: StepID %s, Attempt %d: Received HTTP %d. Retrying after %v...", step.GetStepId(), attempt, httpResp.StatusCode, retryDelay)
+			if attempt < MaxRetries { // Use exported MaxRetries
+				time.Sleep(retryDelay)
+				continue
+			}
+			break // Max retries reached for server-side/rate limit errors
+		}
+
+		// Non-retryable HTTP error or success, break retry loop
+		lastHttpErr = nil // Clear lastHttpErr if we break loop due to non-retryable status or success
+		break
+	}
+
+	// Ensure body is eventually closed if httpResp is not nil
+	if httpResp != nil && httpResp.Body != nil {
+		defer func() {
+			io.Copy(io.Discard, httpResp.Body)
+			httpResp.Body.Close()
+		}()
+	}
+
+	if lastHttpErr != nil { // All retries failed with network/HTTP errors classified as retryable initially
+		res := adapter.ProviderResult{
+			StepID:       step.GetStepId(),
+			Success:      false,
+			ErrorCode:    "NETWORK_ERROR",
+			ErrorMessage: lastHttpErr.Error(),
+			Provider:     "stripe",
+			LatencyMs:    latency.Milliseconds(),
+		}
+		if httpResp != nil {
+			res.HTTPStatus = httpResp.StatusCode
+		}
+		return res, lastHttpErr
+	}
+
+	if httpResp == nil { // Should not happen if lastHttpErr is nil
+		err := errors.New("StripeAdapter.Process: HTTP response is nil after retry loop without error (internal logic error)")
+		return adapter.ProviderResult{
+			StepID:       step.GetStepId(),
+			Success:      false,
+			ErrorCode:    "INTERNAL_ADAPTER_ERROR",
+			ErrorMessage: err.Error(),
+			Provider:     "stripe",
+		}, err
+	}
+
+	respBodyBytes, bodyReadErr := io.ReadAll(httpResp.Body)
+	if bodyReadErr != nil {
+		return adapter.ProviderResult{
+			StepID:       step.GetStepId(),
+			Success:      false,
+			ErrorCode:    "BODY_READ_ERROR",
+			ErrorMessage: fmt.Sprintf("Failed to read response body: %v", bodyReadErr),
+			Provider:     "stripe",
+			LatencyMs:    latency.Milliseconds(),
+			HTTPStatus:   httpResp.StatusCode,
+		}, fmt.Errorf("StripeAdapter.Process: failed to read response body: %w", bodyReadErr)
+	}
+
+	providerResult := adapter.ProviderResult{
+		StepID:       step.GetStepId(),
+		RawResponse:  respBodyBytes, // Changed to []byte
+		LatencyMs:    latency.Milliseconds(),
+		HTTPStatus:   httpResp.StatusCode,
+		Provider:     "stripe",
+	}
+
+	if httpResp.StatusCode >= 200 && httpResp.StatusCode < 300 {
+		var stripeIntent StripePaymentIntent
+		if err := json.Unmarshal(respBodyBytes, &stripeIntent); err != nil {
+			providerResult.Success = false
+			providerResult.ErrorCode = "RESPONSE_UNMARSHAL_ERROR"
+			providerResult.ErrorMessage = fmt.Sprintf("Failed to unmarshal successful Stripe response: %v. Body: %s", err, string(respBodyBytes))
+			return providerResult, fmt.Errorf("StripeAdapter.Process: %s", providerResult.ErrorMessage)
+		}
+		providerResult.TransactionID = stripeIntent.ID
+		switch stripeIntent.Status {
+		case "succeeded", "processing":
+			providerResult.Success = true
+		case "requires_payment_method", "requires_confirmation", "requires_action", "canceled":
+			providerResult.Success = false
+			if stripeIntent.LastPaymentError != nil {
+				providerResult.ErrorCode = stripeIntent.LastPaymentError.Code
+				providerResult.ErrorMessage = stripeIntent.LastPaymentError.Message
+			} else {
+				providerResult.ErrorCode = stripeIntent.Status
+				providerResult.ErrorMessage = fmt.Sprintf("PaymentIntent status: %s", stripeIntent.Status)
+			}
+		default:
+			providerResult.Success = false
+			providerResult.ErrorCode = "UNKNOWN_STRIPE_STATUS"
+			providerResult.ErrorMessage = fmt.Sprintf("Unknown PaymentIntent status: %s", stripeIntent.Status)
+		}
+	} else { // Non-2xx response
+		var stripeErrResp StripeErrorResponse
+		if err := json.Unmarshal(respBodyBytes, &stripeErrResp); err != nil {
+			providerResult.Success = false
+			providerResult.ErrorCode = "ERROR_RESPONSE_UNMARSHAL_ERROR"
+			providerResult.ErrorMessage = fmt.Sprintf("Failed to unmarshal error Stripe response: %v. Body: %s", err, string(respBodyBytes))
+			return providerResult, fmt.Errorf("StripeAdapter.Process: %s", providerResult.ErrorMessage)
+		}
+		providerResult.Success = false
+		if stripeErrResp.Error.Code != "" {
+		    providerResult.ErrorCode = stripeErrResp.Error.Code
+		} else {
+		    providerResult.ErrorCode = fmt.Sprintf("HTTP_%d", httpResp.StatusCode) // Generic error if code is empty
+		}
+		providerResult.ErrorMessage = stripeErrResp.Error.Message
+	}
+	return providerResult, nil
+}
+
+// GetName returns the name of the provider.
+func (sa *StripeAdapter) GetName() string {
+	return "stripe"
+}

--- a/internal/adapter/stripe/stripe_adapter_test.go
+++ b/internal/adapter/stripe/stripe_adapter_test.go
@@ -1,0 +1,326 @@
+package stripe_test
+
+import (
+	// "bytes" // No longer used
+	stdcontext "context" // Standard Go context
+	"encoding/json"
+	"fmt"
+	// "io" // No longer used directly
+	"net/http"
+	"net/http/httptest"
+	"net/url" // Used by url.Error check
+	// "strings" // No longer used
+	"testing"
+	"time"
+
+	// "github.com/google/uuid" // No longer used directly
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	// "github.com/yourorg/payment-orchestrator/internal/adapter" // Not directly used
+	stripe_adapter "github.com/yourorg/payment-orchestrator/internal/adapter/stripe" // aliasing for clarity
+	custom_context "github.com/yourorg/payment-orchestrator/internal/context"
+	orchestratorinternalv1 "github.com/yourorg/payment-orchestrator/pkg/gen/protos/orchestratorinternalv1"
+)
+
+func TestNewStripeAdapter(t *testing.T) {
+	t.Run("Default client and endpoint", func(t *testing.T) {
+		sa := stripe_adapter.NewStripeAdapter(nil, "sk_test_fakekey", "")
+		require.NotNil(t, sa)
+		// Private fields, so can't directly assert them without helpers or reflection.
+		// We can infer by testing behavior in Process or by exposing getters if needed.
+		// For now, just test creation.
+	})
+
+	t.Run("Custom client and endpoint", func(t *testing.T) {
+		customClient := &http.Client{Timeout: 10 * time.Second}
+		customEndpoint := "http://localhost/custom_stripe"
+		sa := stripe_adapter.NewStripeAdapter(customClient, "sk_test_anotherkey", customEndpoint)
+		require.NotNil(t, sa)
+		// Again, direct assertion of private fields is tricky.
+	})
+
+	t.Run("Empty API key logs warning", func(t *testing.T) {
+		// This test is a bit hard to assert directly without capturing log output.
+		// For now, we just call it and rely on manual inspection or more advanced log capture if critical.
+		_ = stripe_adapter.NewStripeAdapter(nil, "", "")
+		// Expect a log message like "StripeAdapter: Warning - API key is empty."
+	})
+}
+
+// TestStripeAdapter_buildStripePayload needs to be a method on a test struct or pass adapter instance
+// to access buildStripePayload if it were private. Since it's an exported method (though probably shouldn't be),
+// we can test it directly IF we instantiate an adapter.
+// However, buildStripePayload is a private method `(sa *StripeAdapter) buildStripePayload`.
+// We can't test it directly from `stripe_test` package.
+// We'll test it indirectly via the `Process` method's behavior regarding payload.
+// For demonstration, if it were EXPORTED, it would look like this:
+/*
+func TestStripeAdapter_BuildStripePayload_Exported(t *testing.T) {
+	sa := stripe_adapter.NewStripeAdapter(nil, "sk_test_fakekey", "")
+	t.Run("Valid step", func(t *testing.T) {
+		step := &orchestratorinternalv1.PaymentStep{
+			Amount:       1000,
+			Currency:     "USD",
+			Metadata:     map[string]string{"description": "Test charge"},
+			ProviderPayload: map[string]string{"stripe_customer_id": "cus_123"},
+		}
+		reader, err := sa.BuildStripePayload(step) // If it were exported
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+		payloadBytes, _ := io.ReadAll(reader)
+		payloadString := string(payloadBytes)
+
+		expectedValues := url.Values{}
+		expectedValues.Set("amount", "1000")
+		expectedValues.Set("currency", "usd")
+		expectedValues.Set("payment_method_types[]", "card")
+		expectedValues.Set("description", "Test charge")
+		expectedValues.Set("customer", "cus_123")
+		assert.Equal(t, expectedValues.Encode(), payloadString)
+	})
+
+	t.Run("Nil step", func(t *testing.T) {
+		_, err := sa.BuildStripePayload(nil) // If it were exported
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "payment step cannot be nil")
+	})
+
+	t.Run("Zero amount", func(t *testing.T) {
+		step := &orchestratorinternalv1.PaymentStep{Amount: 0, Currency: "USD"}
+		_, err := sa.BuildStripePayload(step) // If it were exported
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "payment amount must be positive")
+	})
+
+	t.Run("Empty currency", func(t *testing.T) {
+		step := &orchestratorinternalv1.PaymentStep{Amount: 100, Currency: ""}
+		_, err := sa.BuildStripePayload(step) // If it were exported
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "currency code cannot be empty")
+	})
+}
+*/
+
+// Test for generateIdempotencyKey (private method) would also be indirect,
+// or tested if it were a public helper. We test its effect via Process header check.
+
+// --- Test TestStripeAdapter_Process ---
+
+func setupTestServerAndAdapter(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *stripe_adapter.StripeAdapter) {
+	server := httptest.NewServer(handler)
+	// Use server.Client() to ensure requests are routed to the test server
+	adapter := stripe_adapter.NewStripeAdapter(server.Client(), "sk_test_fakekey", server.URL)
+	return server, adapter
+}
+
+func TestStripeAdapter_Process_SuccessfulPayment(t *testing.T) {
+	expectedAmount := int64(12345)
+	expectedCurrency := "usd"
+	expectedDescription := "Test Purchase"
+	expectedStripeTxnID := "pi_3ExampleSUCCESS"
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		// 1. Verify Headers
+		assert.Equal(t, "Bearer sk_test_fakekey", r.Header.Get("Authorization"))
+		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+		assert.NotEmpty(t, r.Header.Get("Idempotency-Key")) // Check if present
+
+		// 2. Verify Body
+		err := r.ParseForm()
+		require.NoError(t, err)
+		assert.Equal(t, fmt.Sprintf("%d", expectedAmount), r.Form.Get("amount"))
+		assert.Equal(t, expectedCurrency, r.Form.Get("currency"))
+		assert.Equal(t, "card", r.Form.Get("payment_method_types[]"))
+		assert.Equal(t, expectedDescription, r.Form.Get("description"))
+
+		// 3. Respond
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		response := stripe_adapter.StripePaymentIntent{ // Use exported type from stripe_adapter for testing response structure
+			ID:       expectedStripeTxnID,
+			Amount:   expectedAmount,
+			Currency: expectedCurrency,
+			Status:   "succeeded",
+		}
+		json.NewEncoder(w).Encode(response)
+	}
+
+	server, sa := setupTestServerAndAdapter(t, handler)
+	defer server.Close()
+
+	traceCtx := custom_context.NewTraceContext()
+	step := &orchestratorinternalv1.PaymentStep{
+		Amount:   expectedAmount,
+		Currency: expectedCurrency,
+		Metadata: map[string]string{"description": expectedDescription},
+	}
+	stepCtx := custom_context.StepExecutionContext{StartTime: time.Now(), RemainingBudgetMs: 5000}
+
+	result, err := sa.Process(traceCtx, step, stepCtx)
+
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, expectedStripeTxnID, result.TransactionID)
+	assert.Equal(t, "stripe", result.Provider)
+	assert.Equal(t, http.StatusOK, result.HTTPStatus)
+	require.NotEmpty(t, result.RawResponse)
+	assert.True(t, result.LatencyMs >= 0) // Latency can be very small, >=0
+}
+
+func TestStripeAdapter_Process_StripeApiError(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusPaymentRequired) // 402
+		response := stripe_adapter.StripeErrorResponse{
+			Error: stripe_adapter.StripeError{
+				Code:    "card_declined",
+				Message: "Your card was declined.",
+				Type:    "card_error",
+				DeclineCode: "generic_decline",
+			},
+		}
+		json.NewEncoder(w).Encode(response)
+	}
+
+	server, sa := setupTestServerAndAdapter(t, handler)
+	defer server.Close()
+
+	traceCtx := custom_context.NewTraceContext()
+	step := &orchestratorinternalv1.PaymentStep{Amount: 1000, Currency: "usd"}
+	stepCtx := custom_context.StepExecutionContext{StartTime: time.Now(), RemainingBudgetMs: 5000}
+
+	result, err := sa.Process(traceCtx, step, stepCtx)
+
+	require.NoError(t, err) // Process itself doesn't error for API errors, error is in result
+	assert.False(t, result.Success)
+	assert.Equal(t, "card_declined", result.ErrorCode)
+	assert.Equal(t, "Your card was declined.", result.ErrorMessage)
+	assert.Equal(t, http.StatusPaymentRequired, result.HTTPStatus)
+}
+
+
+func TestStripeAdapter_Process_RetryOn500_ThenSuccess(t *testing.T) {
+	numRequests := 0
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		numRequests++
+		idempotencyKey := r.Header.Get("Idempotency-Key")
+		require.NotEmpty(t, idempotencyKey) // Should be present on all attempts
+
+		if numRequests == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		// Second attempt
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		response := stripe_adapter.StripePaymentIntent{ID: "pi_retrySuccess", Status: "succeeded"}
+		json.NewEncoder(w).Encode(response)
+	}
+
+	server, sa := setupTestServerAndAdapter(t, handler)
+	defer server.Close()
+
+	traceCtx := custom_context.NewTraceContext()
+	step := &orchestratorinternalv1.PaymentStep{Amount: 1000, Currency: "usd"}
+	stepCtx := custom_context.StepExecutionContext{StartTime: time.Now(), RemainingBudgetMs: 5000}
+
+	result, err := sa.Process(traceCtx, step, stepCtx)
+
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, 2, numRequests)
+	assert.Equal(t, http.StatusOK, result.HTTPStatus)
+	assert.Equal(t, "pi_retrySuccess", result.TransactionID)
+}
+
+func TestStripeAdapter_Process_Retry_MaxRetriesExhausted(t *testing.T) {
+	numRequests := 0
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		numRequests++
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+
+	server, sa := setupTestServerAndAdapter(t, handler)
+	defer server.Close()
+
+	traceCtx := custom_context.NewTraceContext()
+	step := &orchestratorinternalv1.PaymentStep{Amount: 1000, Currency: "usd"}
+	stepCtx := custom_context.StepExecutionContext{StartTime: time.Now(), RemainingBudgetMs: 5000}
+
+	result, err := sa.Process(traceCtx, step, stepCtx)
+
+	require.Error(t, err) // Should return the last error
+	assert.False(t, result.Success)
+	assert.Equal(t, "NETWORK_ERROR", result.ErrorCode)
+	assert.Contains(t, result.ErrorMessage, "received HTTP 500")
+	assert.Equal(t, http.StatusInternalServerError, result.HTTPStatus)
+	assert.Equal(t, stripe_adapter.MaxRetries+1, numRequests) // Initial attempt + MaxRetries
+}
+
+func TestStripeAdapter_Process_InvalidJsonResponse_SuccessStatus(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id": "pi_123", "status": "succeeded", malformed_json`) // Invalid JSON
+	}
+	server, sa := setupTestServerAndAdapter(t, handler)
+	defer server.Close()
+
+	result, err := sa.Process(custom_context.NewTraceContext(), &orchestratorinternalv1.PaymentStep{Amount: 1000, Currency: "usd"}, custom_context.StepExecutionContext{StartTime: time.Now(), RemainingBudgetMs: 5000})
+
+	require.Error(t, err)
+	assert.False(t, result.Success)
+	assert.Equal(t, "RESPONSE_UNMARSHAL_ERROR", result.ErrorCode)
+	assert.Contains(t, err.Error(), "Failed to unmarshal successful Stripe response")
+}
+
+func TestStripeAdapter_Process_InvalidJsonResponse_ErrorStatus(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest) // 400
+		fmt.Fprint(w, `{"error": {"code": "invalid_request", malformed_json`) // Invalid JSON
+	}
+	server, sa := setupTestServerAndAdapter(t, handler)
+	defer server.Close()
+
+	result, err := sa.Process(custom_context.NewTraceContext(), &orchestratorinternalv1.PaymentStep{Amount: 1000, Currency: "usd"}, custom_context.StepExecutionContext{StartTime: time.Now(), RemainingBudgetMs: 5000})
+
+	require.Error(t, err)
+	assert.False(t, result.Success)
+	// The adapter code has ERROR_RESPONSE_UNMARSHAL_ERROR for this.
+	assert.Equal(t, "ERROR_RESPONSE_UNMARSHAL_ERROR", result.ErrorCode)
+	assert.Contains(t, err.Error(), "Failed to unmarshal error Stripe response")
+}
+
+func TestStripeAdapter_Process_RequestTimeout(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond) // Sleep longer than context timeout
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"pi_timeout","status":"succeeded"}`)
+	}
+	server, sa := setupTestServerAndAdapter(t, handler)
+	defer server.Close()
+
+	traceCtx := custom_context.NewTraceContext()
+	// Short budget for timeout
+	stepCtx := custom_context.StepExecutionContext{StartTime: time.Now(), RemainingBudgetMs: 50}
+	step := &orchestratorinternalv1.PaymentStep{Amount: 1000, Currency: "usd"}
+
+	result, err := sa.Process(traceCtx, step, stepCtx)
+
+	require.Error(t, err)
+	assert.False(t, result.Success)
+	assert.Equal(t, "NETWORK_ERROR", result.ErrorCode) // Context deadline exceeded is a network error
+	// Check that the error is indeed a context deadline exceeded error
+	if ue, ok := err.(*url.Error); ok { // HTTP client errors are often wrapped in url.Error
+		assert.ErrorIs(t, ue.Err, stdcontext.DeadlineExceeded)
+	} else {
+		assert.ErrorIs(t, err, stdcontext.DeadlineExceeded) // Fallback check
+	}
+}
+
+func TestStripeAdapter_GetName(t *testing.T) {
+	sa := stripe_adapter.NewStripeAdapter(nil, "sk_test_fakekey", "")
+	assert.Equal(t, "stripe", sa.GetName())
+}


### PR DESCRIPTION
This commit introduces a simple StripeAdapter implementation as per Chunk 11.

Key changes:

`internal/adapter/stripe/stripe_adapter.go`:
- Defined `StripeAdapter` struct holding an HTTP client, API key, and Stripe API endpoint.
- Implemented `NewStripeAdapter` constructor with defaults.
- Implemented helper functions:
    - `generateIdempotencyKey()`: Returns a UUID string.
    - `buildStripePayload()`: Creates an `io.Reader` for an `x-www-form-urlencoded` request body from a `PaymentStep`, including amount, currency, and hardcoded `payment_method_types[]=card`.
- Implemented the `Process(traceCtx TraceContext, step *PaymentStep, stepCtx StepExecutionContext) (ProviderResult, error)` method:
    - Constructs HTTP POST requests to the Stripe API.
    - Includes `Authorization`, `Content-Type`, and `Idempotency-Key` headers.
    - Uses `stepCtx.RemainingBudgetMs` for request context timeout.
    - Implements a retry mechanism (default 1 retry) for network errors, HTTP 5xx, and HTTP 429 status codes.
    - Parses Stripe's JSON responses for success (`StripePaymentIntent`) and errors (`StripeErrorResponse`).
    - Maps Stripe PaymentIntent statuses (e.g., "succeeded", "requires_payment_method") to `adapter.ProviderResult.Success`.
    - Populates `adapter.ProviderResult` with transaction ID, error codes/messages, raw response (`[]byte`), latency, HTTP status, and provider name.
- Implemented `GetName() string` method, returning "stripe".

`internal/adapter/stripe/stripe_adapter_test.go`:
- Created comprehensive unit tests for `StripeAdapter`.
- Tested `NewStripeAdapter` and `GetName()`.
- Used `httptest.NewServer` to mock Stripe API behavior for `Process` method tests, covering:
    - Successful payment processing.
    - Various Stripe API error responses.
    - Retry logic (success on retry, retries exhausted).
    - Handling of invalid/malformed JSON responses from the mock server.
    - Request timeouts based on `StepExecutionContext.RemainingBudgetMs`.
    - Verification of request headers and payload.

This adapter provides the first concrete implementation for interacting with a payment provider, including essential features like retry logic and detailed response handling.