### PR TITLE
feat: Implement Chunk 12, Task 19 - Circuit Breaker Service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,5 +13,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
@@ -6,6 +7,12 @@ github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
@@ -14,5 +21,6 @@ google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9x
 google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -23,6 +23,7 @@ type ProviderResult struct {
 	TransactionID string            // Transaction ID from the provider, if successful
 	LatencyMs     int64             // Latency of the call to the provider
 	RawResponse   []byte            // Raw response body from the provider (for debugging/logging)
+	HTTPStatus    int               // HTTP status code from the provider's response
 	Details       map[string]string // Any other relevant details from the provider
 }
 

--- a/internal/adapter/stripe/stripe_adapter.go
+++ b/internal/adapter/stripe/stripe_adapter.go
@@ -1,0 +1,318 @@
+package stripe
+
+import (
+	// "bytes" // No longer used
+	stdcontext "context" // Standard Go context, aliased to avoid collision
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/yourorg/payment-orchestrator/internal/adapter"
+	"github.com/yourorg/payment-orchestrator/internal/context" // For our custom TraceContext, StepExecutionContext
+	orchestratorinternalv1 "github.com/yourorg/payment-orchestrator/pkg/gen/protos/orchestratorinternalv1"
+)
+
+// StripeAdapter handles communication with the Stripe API.
+type StripeAdapter struct {
+	httpClient *http.Client
+	apiKey     string
+	endpoint   string // e.g., "https://api.stripe.com/v1/payment_intents"
+}
+
+// NewStripeAdapter creates a new instance of StripeAdapter.
+func NewStripeAdapter(client *http.Client, apiKey string, apiEndpoint string) *StripeAdapter {
+	if client == nil {
+		client = &http.Client{}
+	}
+	if apiEndpoint == "" {
+		apiEndpoint = "https://api.stripe.com/v1/payment_intents"
+	}
+	if apiKey == "" {
+		log.Println("StripeAdapter: Warning - API key is empty.") // Or panic, depending on desired strictness
+	}
+	return &StripeAdapter{
+		httpClient: client,
+		apiKey:     apiKey,
+		endpoint:   apiEndpoint,
+	}
+}
+
+// generateIdempotencyKey creates a unique key for Stripe idempotency.
+func (sa *StripeAdapter) generateIdempotencyKey() string {
+	return uuid.NewString()
+}
+
+// buildStripePayload creates an io.Reader for the x-www-form-urlencoded Stripe request body.
+func (sa *StripeAdapter) buildStripePayload(step *orchestratorinternalv1.PaymentStep) (io.Reader, error) {
+	if step == nil {
+		return nil, fmt.Errorf("stripe: payment step cannot be nil")
+	}
+	if step.GetAmount() <= 0 {
+		return nil, fmt.Errorf("stripe: payment amount must be positive, got %d", step.GetAmount())
+	}
+	if step.GetCurrency() == "" {
+		return nil, fmt.Errorf("stripe: currency code cannot be empty")
+	}
+
+	data := url.Values{}
+	data.Set("amount", fmt.Sprintf("%d", step.GetAmount()))
+	data.Set("currency", strings.ToLower(step.GetCurrency()))
+	data.Set("payment_method_types[]", "card")
+
+	if desc, ok := step.GetMetadata()["description"]; ok {
+		data.Set("description", desc)
+	}
+	if sd, ok := step.GetMetadata()["statement_descriptor"]; ok {
+		data.Set("statement_descriptor", sd)
+	}
+	if customerID, ok := step.GetProviderPayload()["stripe_customer_id"]; ok {
+		data.Set("customer", customerID)
+	}
+	if paymentMethodID, ok := step.GetProviderPayload()["stripe_payment_method_id"]; ok {
+		data.Set("payment_method", paymentMethodID)
+		// data.Set("confirm", "true") // Auto-confirm if payment_method is provided; consider if this is always desired
+	}
+	return strings.NewReader(data.Encode()), nil
+}
+
+// --- Stripe API Response Structs ---
+type StripeError struct {
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Type        string `json:"type"`
+	DeclineCode string `json:"decline_code,omitempty"`
+}
+
+type StripeErrorResponse struct {
+	Error StripeError `json:"error"`
+}
+
+type StripePaymentIntent struct {
+	ID                   string            `json:"id"`
+	Amount               int64             `json:"amount"`
+	Currency             string            `json:"currency"`
+	Status               string            `json:"status"`
+	ClientSecret         string            `json:"client_secret,omitempty"`
+	LastPaymentError     *StripeError      `json:"last_payment_error,omitempty"`
+	Metadata             map[string]string `json:"metadata,omitempty"`
+}
+
+// --- Process Method ---
+const MaxRetries = 1 // Exported for test access
+const retryDelay = 500 * time.Millisecond
+
+// Process handles a single payment step using the Stripe provider logic.
+func (sa *StripeAdapter) Process(
+	traceCtx context.TraceContext, // Our custom TraceContext
+	step *orchestratorinternalv1.PaymentStep,
+	stepCtx context.StepExecutionContext, // Our custom StepExecutionContext
+) (adapter.ProviderResult, error) {
+
+	payload, err := sa.buildStripePayload(step)
+	if err != nil {
+		return adapter.ProviderResult{
+			StepID:       step.GetStepId(),
+			Success:      false,
+			ErrorCode:    "PAYLOAD_BUILD_ERROR",
+			ErrorMessage: err.Error(),
+			Provider:     "stripe",
+		}, fmt.Errorf("StripeAdapter.Process: failed to build payload: %w", err)
+	}
+
+	idempotencyKey := sa.generateIdempotencyKey()
+	var lastHttpErr error
+	var httpResp *http.Response
+	var latency time.Duration
+
+	// Use stdcontext.Background() for the HTTP request context for now.
+	// Ideally, a context would be passed down from the initial request, incorporating timeouts/cancellation.
+	// stepCtx.RemainingBudgetMs could be used to create a derived context with timeout.
+	reqCtx := stdcontext.Background()
+	if stepCtx.RemainingBudgetMs > 0 {
+		timeout := time.Duration(stepCtx.RemainingBudgetMs) * time.Millisecond
+		var cancel stdcontext.CancelFunc
+		reqCtx, cancel = stdcontext.WithTimeout(reqCtx, timeout)
+		defer cancel() // Ensure cancel is called to free resources
+	}
+
+
+	for attempt := 0; attempt <= MaxRetries; attempt++ { // Use exported MaxRetries
+		// For retries, the payload might need to be re-created if it's an io.Reader that gets consumed.
+		// strings.NewReader can be read multiple times, but if it were from a one-time stream, care is needed.
+		// For url.Values, data.Encode() can be called again or the string stored.
+		// Since buildStripePayload returns a new strings.NewReader each time, it's fine to call it again if needed,
+		// but for now, we assume the payload reader can be reused or the body is not the cause of retryable errors.
+		// If payload was an `io.ReadCloser` it would be more complex. `strings.NewReader` is fine.
+
+		var currentPayload io.Reader = payload
+		if attempt > 0 { // If retrying, ensure payload can be read again
+		    currentPayload, err = sa.buildStripePayload(step) // Rebuild to be safe for retries
+		    if err != nil {
+		        return adapter.ProviderResult{
+					StepID: step.GetStepId(), Success: false, ErrorCode: "PAYLOAD_REBUILD_ERROR", ErrorMessage: err.Error(), Provider: "stripe"},
+					fmt.Errorf("StripeAdapter.Process: failed to rebuild payload for retry: %w", err)
+			}
+		}
+
+
+		httpReq, err := http.NewRequestWithContext(reqCtx, http.MethodPost, sa.endpoint, currentPayload)
+		if err != nil {
+			// This is a non-retryable error for this attempt, likely fatal for the process.
+			return adapter.ProviderResult{
+				StepID:       step.GetStepId(),
+				Success:      false,
+				ErrorCode:    "REQUEST_CREATION_ERROR",
+				ErrorMessage: err.Error(),
+				Provider:     "stripe",
+			}, fmt.Errorf("StripeAdapter.Process: failed to create http request: %w", err)
+		}
+
+		httpReq.Header.Set("Authorization", "Bearer "+sa.apiKey)
+		httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		httpReq.Header.Set("Idempotency-Key", idempotencyKey)
+		// Consider adding "Stripe-Version" header
+
+		startTime := time.Now()
+		httpResp, err = sa.httpClient.Do(httpReq)
+		latency = time.Since(startTime)
+
+		if err != nil {
+			lastHttpErr = fmt.Errorf("attempt %d: http client error: %w", attempt, err)
+			log.Printf("StripeAdapter.Process: StepID %s, Attempt %d: HTTP client error: %v. Retrying after %v...", step.GetStepId(), attempt, err, retryDelay)
+			if attempt < MaxRetries { // Use exported MaxRetries
+				time.Sleep(retryDelay)
+				continue
+			}
+			break // Max retries reached for this type of error
+		}
+
+		// Successful HTTP request, now check status code
+		if httpResp.StatusCode >= 500 || httpResp.StatusCode == http.StatusTooManyRequests {
+			respBodyBytes, _ := io.ReadAll(httpResp.Body) // Read to log/include in error
+			httpResp.Body.Close() // Close body immediately after read
+
+			lastHttpErr = fmt.Errorf("attempt %d: received HTTP %d: %s", attempt, httpResp.StatusCode, string(respBodyBytes))
+			log.Printf("StripeAdapter.Process: StepID %s, Attempt %d: Received HTTP %d. Retrying after %v...", step.GetStepId(), attempt, httpResp.StatusCode, retryDelay)
+			if attempt < MaxRetries { // Use exported MaxRetries
+				time.Sleep(retryDelay)
+				continue
+			}
+			break // Max retries reached for server-side/rate limit errors
+		}
+
+		// Non-retryable HTTP error or success, break retry loop
+		lastHttpErr = nil // Clear lastHttpErr if we break loop due to non-retryable status or success
+		break
+	}
+
+	// Ensure body is eventually closed if httpResp is not nil
+	if httpResp != nil && httpResp.Body != nil {
+		defer func() {
+			io.Copy(io.Discard, httpResp.Body)
+			httpResp.Body.Close()
+		}()
+	}
+
+	if lastHttpErr != nil { // All retries failed with network/HTTP errors classified as retryable initially
+		res := adapter.ProviderResult{
+			StepID:       step.GetStepId(),
+			Success:      false,
+			ErrorCode:    "NETWORK_ERROR",
+			ErrorMessage: lastHttpErr.Error(),
+			Provider:     "stripe",
+			LatencyMs:    latency.Milliseconds(),
+		}
+		if httpResp != nil {
+			res.HTTPStatus = httpResp.StatusCode
+		}
+		return res, lastHttpErr
+	}
+
+	if httpResp == nil { // Should not happen if lastHttpErr is nil
+		err := errors.New("StripeAdapter.Process: HTTP response is nil after retry loop without error (internal logic error)")
+		return adapter.ProviderResult{
+			StepID:       step.GetStepId(),
+			Success:      false,
+			ErrorCode:    "INTERNAL_ADAPTER_ERROR",
+			ErrorMessage: err.Error(),
+			Provider:     "stripe",
+		}, err
+	}
+
+	respBodyBytes, bodyReadErr := io.ReadAll(httpResp.Body)
+	if bodyReadErr != nil {
+		return adapter.ProviderResult{
+			StepID:       step.GetStepId(),
+			Success:      false,
+			ErrorCode:    "BODY_READ_ERROR",
+			ErrorMessage: fmt.Sprintf("Failed to read response body: %v", bodyReadErr),
+			Provider:     "stripe",
+			LatencyMs:    latency.Milliseconds(),
+			HTTPStatus:   httpResp.StatusCode,
+		}, fmt.Errorf("StripeAdapter.Process: failed to read response body: %w", bodyReadErr)
+	}
+
+	providerResult := adapter.ProviderResult{
+		StepID:       step.GetStepId(),
+		RawResponse:  respBodyBytes, // Changed to []byte
+		LatencyMs:    latency.Milliseconds(),
+		HTTPStatus:   httpResp.StatusCode,
+		Provider:     "stripe",
+	}
+
+	if httpResp.StatusCode >= 200 && httpResp.StatusCode < 300 {
+		var stripeIntent StripePaymentIntent
+		if err := json.Unmarshal(respBodyBytes, &stripeIntent); err != nil {
+			providerResult.Success = false
+			providerResult.ErrorCode = "RESPONSE_UNMARSHAL_ERROR"
+			providerResult.ErrorMessage = fmt.Sprintf("Failed to unmarshal successful Stripe response: %v. Body: %s", err, string(respBodyBytes))
+			return providerResult, fmt.Errorf("StripeAdapter.Process: %s", providerResult.ErrorMessage)
+		}
+		providerResult.TransactionID = stripeIntent.ID
+		switch stripeIntent.Status {
+		case "succeeded", "processing":
+			providerResult.Success = true
+		case "requires_payment_method", "requires_confirmation", "requires_action", "canceled":
+			providerResult.Success = false
+			if stripeIntent.LastPaymentError != nil {
+				providerResult.ErrorCode = stripeIntent.LastPaymentError.Code
+				providerResult.ErrorMessage = stripeIntent.LastPaymentError.Message
+			} else {
+				providerResult.ErrorCode = stripeIntent.Status
+				providerResult.ErrorMessage = fmt.Sprintf("PaymentIntent status: %s", stripeIntent.Status)
+			}
+		default:
+			providerResult.Success = false
+			providerResult.ErrorCode = "UNKNOWN_STRIPE_STATUS"
+			providerResult.ErrorMessage = fmt.Sprintf("Unknown PaymentIntent status: %s", stripeIntent.Status)
+		}
+	} else { // Non-2xx response
+		var stripeErrResp StripeErrorResponse
+		if err := json.Unmarshal(respBodyBytes, &stripeErrResp); err != nil {
+			providerResult.Success = false
+			providerResult.ErrorCode = "ERROR_RESPONSE_UNMARSHAL_ERROR"
+			providerResult.ErrorMessage = fmt.Sprintf("Failed to unmarshal error Stripe response: %v. Body: %s", err, string(respBodyBytes))
+			return providerResult, fmt.Errorf("StripeAdapter.Process: %s", providerResult.ErrorMessage)
+		}
+		providerResult.Success = false
+		if stripeErrResp.Error.Code != "" {
+		    providerResult.ErrorCode = stripeErrResp.Error.Code
+		} else {
+		    providerResult.ErrorCode = fmt.Sprintf("HTTP_%d", httpResp.StatusCode) // Generic error if code is empty
+		}
+		providerResult.ErrorMessage = stripeErrResp.Error.Message
+	}
+	return providerResult, nil
+}
+
+// GetName returns the name of the provider.
+func (sa *StripeAdapter) GetName() string {
+	return "stripe"
+}

--- a/internal/adapter/stripe/stripe_adapter_test.go
+++ b/internal/adapter/stripe/stripe_adapter_test.go
@@ -1,0 +1,326 @@
+package stripe_test
+
+import (
+	// "bytes" // No longer used
+	stdcontext "context" // Standard Go context
+	"encoding/json"
+	"fmt"
+	// "io" // No longer used directly
+	"net/http"
+	"net/http/httptest"
+	"net/url" // Used by url.Error check
+	// "strings" // No longer used
+	"testing"
+	"time"
+
+	// "github.com/google/uuid" // No longer used directly
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	// "github.com/yourorg/payment-orchestrator/internal/adapter" // Not directly used
+	stripe_adapter "github.com/yourorg/payment-orchestrator/internal/adapter/stripe" // aliasing for clarity
+	custom_context "github.com/yourorg/payment-orchestrator/internal/context"
+	orchestratorinternalv1 "github.com/yourorg/payment-orchestrator/pkg/gen/protos/orchestratorinternalv1"
+)
+
+func TestNewStripeAdapter(t *testing.T) {
+	t.Run("Default client and endpoint", func(t *testing.T) {
+		sa := stripe_adapter.NewStripeAdapter(nil, "sk_test_fakekey", "")
+		require.NotNil(t, sa)
+		// Private fields, so can't directly assert them without helpers or reflection.
+		// We can infer by testing behavior in Process or by exposing getters if needed.
+		// For now, just test creation.
+	})
+
+	t.Run("Custom client and endpoint", func(t *testing.T) {
+		customClient := &http.Client{Timeout: 10 * time.Second}
+		customEndpoint := "http://localhost/custom_stripe"
+		sa := stripe_adapter.NewStripeAdapter(customClient, "sk_test_anotherkey", customEndpoint)
+		require.NotNil(t, sa)
+		// Again, direct assertion of private fields is tricky.
+	})
+
+	t.Run("Empty API key logs warning", func(t *testing.T) {
+		// This test is a bit hard to assert directly without capturing log output.
+		// For now, we just call it and rely on manual inspection or more advanced log capture if critical.
+		_ = stripe_adapter.NewStripeAdapter(nil, "", "")
+		// Expect a log message like "StripeAdapter: Warning - API key is empty."
+	})
+}
+
+// TestStripeAdapter_buildStripePayload needs to be a method on a test struct or pass adapter instance
+// to access buildStripePayload if it were private. Since it's an exported method (though probably shouldn't be),
+// we can test it directly IF we instantiate an adapter.
+// However, buildStripePayload is a private method `(sa *StripeAdapter) buildStripePayload`.
+// We can't test it directly from `stripe_test` package.
+// We'll test it indirectly via the `Process` method's behavior regarding payload.
+// For demonstration, if it were EXPORTED, it would look like this:
+/*
+func TestStripeAdapter_BuildStripePayload_Exported(t *testing.T) {
+	sa := stripe_adapter.NewStripeAdapter(nil, "sk_test_fakekey", "")
+	t.Run("Valid step", func(t *testing.T) {
+		step := &orchestratorinternalv1.PaymentStep{
+			Amount:       1000,
+			Currency:     "USD",
+			Metadata:     map[string]string{"description": "Test charge"},
+			ProviderPayload: map[string]string{"stripe_customer_id": "cus_123"},
+		}
+		reader, err := sa.BuildStripePayload(step) // If it were exported
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+		payloadBytes, _ := io.ReadAll(reader)
+		payloadString := string(payloadBytes)
+
+		expectedValues := url.Values{}
+		expectedValues.Set("amount", "1000")
+		expectedValues.Set("currency", "usd")
+		expectedValues.Set("payment_method_types[]", "card")
+		expectedValues.Set("description", "Test charge")
+		expectedValues.Set("customer", "cus_123")
+		assert.Equal(t, expectedValues.Encode(), payloadString)
+	})
+
+	t.Run("Nil step", func(t *testing.T) {
+		_, err := sa.BuildStripePayload(nil) // If it were exported
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "payment step cannot be nil")
+	})
+
+	t.Run("Zero amount", func(t *testing.T) {
+		step := &orchestratorinternalv1.PaymentStep{Amount: 0, Currency: "USD"}
+		_, err := sa.BuildStripePayload(step) // If it were exported
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "payment amount must be positive")
+	})
+
+	t.Run("Empty currency", func(t *testing.T) {
+		step := &orchestratorinternalv1.PaymentStep{Amount: 100, Currency: ""}
+		_, err := sa.BuildStripePayload(step) // If it were exported
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "currency code cannot be empty")
+	})
+}
+*/
+
+// Test for generateIdempotencyKey (private method) would also be indirect,
+// or tested if it were a public helper. We test its effect via Process header check.
+
+// --- Test TestStripeAdapter_Process ---
+
+func setupTestServerAndAdapter(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *stripe_adapter.StripeAdapter) {
+	server := httptest.NewServer(handler)
+	// Use server.Client() to ensure requests are routed to the test server
+	adapter := stripe_adapter.NewStripeAdapter(server.Client(), "sk_test_fakekey", server.URL)
+	return server, adapter
+}
+
+func TestStripeAdapter_Process_SuccessfulPayment(t *testing.T) {
+	expectedAmount := int64(12345)
+	expectedCurrency := "usd"
+	expectedDescription := "Test Purchase"
+	expectedStripeTxnID := "pi_3ExampleSUCCESS"
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		// 1. Verify Headers
+		assert.Equal(t, "Bearer sk_test_fakekey", r.Header.Get("Authorization"))
+		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+		assert.NotEmpty(t, r.Header.Get("Idempotency-Key")) // Check if present
+
+		// 2. Verify Body
+		err := r.ParseForm()
+		require.NoError(t, err)
+		assert.Equal(t, fmt.Sprintf("%d", expectedAmount), r.Form.Get("amount"))
+		assert.Equal(t, expectedCurrency, r.Form.Get("currency"))
+		assert.Equal(t, "card", r.Form.Get("payment_method_types[]"))
+		assert.Equal(t, expectedDescription, r.Form.Get("description"))
+
+		// 3. Respond
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		response := stripe_adapter.StripePaymentIntent{ // Use exported type from stripe_adapter for testing response structure
+			ID:       expectedStripeTxnID,
+			Amount:   expectedAmount,
+			Currency: expectedCurrency,
+			Status:   "succeeded",
+		}
+		json.NewEncoder(w).Encode(response)
+	}
+
+	server, sa := setupTestServerAndAdapter(t, handler)
+	defer server.Close()
+
+	traceCtx := custom_context.NewTraceContext()
+	step := &orchestratorinternalv1.PaymentStep{
+		Amount:   expectedAmount,
+		Currency: expectedCurrency,
+		Metadata: map[string]string{"description": expectedDescription},
+	}
+	stepCtx := custom_context.StepExecutionContext{StartTime: time.Now(), RemainingBudgetMs: 5000}
+
+	result, err := sa.Process(traceCtx, step, stepCtx)
+
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, expectedStripeTxnID, result.TransactionID)
+	assert.Equal(t, "stripe", result.Provider)
+	assert.Equal(t, http.StatusOK, result.HTTPStatus)
+	require.NotEmpty(t, result.RawResponse)
+	assert.True(t, result.LatencyMs >= 0) // Latency can be very small, >=0
+}
+
+func TestStripeAdapter_Process_StripeApiError(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusPaymentRequired) // 402
+		response := stripe_adapter.StripeErrorResponse{
+			Error: stripe_adapter.StripeError{
+				Code:    "card_declined",
+				Message: "Your card was declined.",
+				Type:    "card_error",
+				DeclineCode: "generic_decline",
+			},
+		}
+		json.NewEncoder(w).Encode(response)
+	}
+
+	server, sa := setupTestServerAndAdapter(t, handler)
+	defer server.Close()
+
+	traceCtx := custom_context.NewTraceContext()
+	step := &orchestratorinternalv1.PaymentStep{Amount: 1000, Currency: "usd"}
+	stepCtx := custom_context.StepExecutionContext{StartTime: time.Now(), RemainingBudgetMs: 5000}
+
+	result, err := sa.Process(traceCtx, step, stepCtx)
+
+	require.NoError(t, err) // Process itself doesn't error for API errors, error is in result
+	assert.False(t, result.Success)
+	assert.Equal(t, "card_declined", result.ErrorCode)
+	assert.Equal(t, "Your card was declined.", result.ErrorMessage)
+	assert.Equal(t, http.StatusPaymentRequired, result.HTTPStatus)
+}
+
+
+func TestStripeAdapter_Process_RetryOn500_ThenSuccess(t *testing.T) {
+	numRequests := 0
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		numRequests++
+		idempotencyKey := r.Header.Get("Idempotency-Key")
+		require.NotEmpty(t, idempotencyKey) // Should be present on all attempts
+
+		if numRequests == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		// Second attempt
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		response := stripe_adapter.StripePaymentIntent{ID: "pi_retrySuccess", Status: "succeeded"}
+		json.NewEncoder(w).Encode(response)
+	}
+
+	server, sa := setupTestServerAndAdapter(t, handler)
+	defer server.Close()
+
+	traceCtx := custom_context.NewTraceContext()
+	step := &orchestratorinternalv1.PaymentStep{Amount: 1000, Currency: "usd"}
+	stepCtx := custom_context.StepExecutionContext{StartTime: time.Now(), RemainingBudgetMs: 5000}
+
+	result, err := sa.Process(traceCtx, step, stepCtx)
+
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, 2, numRequests)
+	assert.Equal(t, http.StatusOK, result.HTTPStatus)
+	assert.Equal(t, "pi_retrySuccess", result.TransactionID)
+}
+
+func TestStripeAdapter_Process_Retry_MaxRetriesExhausted(t *testing.T) {
+	numRequests := 0
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		numRequests++
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+
+	server, sa := setupTestServerAndAdapter(t, handler)
+	defer server.Close()
+
+	traceCtx := custom_context.NewTraceContext()
+	step := &orchestratorinternalv1.PaymentStep{Amount: 1000, Currency: "usd"}
+	stepCtx := custom_context.StepExecutionContext{StartTime: time.Now(), RemainingBudgetMs: 5000}
+
+	result, err := sa.Process(traceCtx, step, stepCtx)
+
+	require.Error(t, err) // Should return the last error
+	assert.False(t, result.Success)
+	assert.Equal(t, "NETWORK_ERROR", result.ErrorCode)
+	assert.Contains(t, result.ErrorMessage, "received HTTP 500")
+	assert.Equal(t, http.StatusInternalServerError, result.HTTPStatus)
+	assert.Equal(t, stripe_adapter.MaxRetries+1, numRequests) // Initial attempt + MaxRetries
+}
+
+func TestStripeAdapter_Process_InvalidJsonResponse_SuccessStatus(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id": "pi_123", "status": "succeeded", malformed_json`) // Invalid JSON
+	}
+	server, sa := setupTestServerAndAdapter(t, handler)
+	defer server.Close()
+
+	result, err := sa.Process(custom_context.NewTraceContext(), &orchestratorinternalv1.PaymentStep{Amount: 1000, Currency: "usd"}, custom_context.StepExecutionContext{StartTime: time.Now(), RemainingBudgetMs: 5000})
+
+	require.Error(t, err)
+	assert.False(t, result.Success)
+	assert.Equal(t, "RESPONSE_UNMARSHAL_ERROR", result.ErrorCode)
+	assert.Contains(t, err.Error(), "Failed to unmarshal successful Stripe response")
+}
+
+func TestStripeAdapter_Process_InvalidJsonResponse_ErrorStatus(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest) // 400
+		fmt.Fprint(w, `{"error": {"code": "invalid_request", malformed_json`) // Invalid JSON
+	}
+	server, sa := setupTestServerAndAdapter(t, handler)
+	defer server.Close()
+
+	result, err := sa.Process(custom_context.NewTraceContext(), &orchestratorinternalv1.PaymentStep{Amount: 1000, Currency: "usd"}, custom_context.StepExecutionContext{StartTime: time.Now(), RemainingBudgetMs: 5000})
+
+	require.Error(t, err)
+	assert.False(t, result.Success)
+	// The adapter code has ERROR_RESPONSE_UNMARSHAL_ERROR for this.
+	assert.Equal(t, "ERROR_RESPONSE_UNMARSHAL_ERROR", result.ErrorCode)
+	assert.Contains(t, err.Error(), "Failed to unmarshal error Stripe response")
+}
+
+func TestStripeAdapter_Process_RequestTimeout(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond) // Sleep longer than context timeout
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"pi_timeout","status":"succeeded"}`)
+	}
+	server, sa := setupTestServerAndAdapter(t, handler)
+	defer server.Close()
+
+	traceCtx := custom_context.NewTraceContext()
+	// Short budget for timeout
+	stepCtx := custom_context.StepExecutionContext{StartTime: time.Now(), RemainingBudgetMs: 50}
+	step := &orchestratorinternalv1.PaymentStep{Amount: 1000, Currency: "usd"}
+
+	result, err := sa.Process(traceCtx, step, stepCtx)
+
+	require.Error(t, err)
+	assert.False(t, result.Success)
+	assert.Equal(t, "NETWORK_ERROR", result.ErrorCode) // Context deadline exceeded is a network error
+	// Check that the error is indeed a context deadline exceeded error
+	if ue, ok := err.(*url.Error); ok { // HTTP client errors are often wrapped in url.Error
+		assert.ErrorIs(t, ue.Err, stdcontext.DeadlineExceeded)
+	} else {
+		assert.ErrorIs(t, err, stdcontext.DeadlineExceeded) // Fallback check
+	}
+}
+
+func TestStripeAdapter_GetName(t *testing.T) {
+	sa := stripe_adapter.NewStripeAdapter(nil, "sk_test_fakekey", "")
+	assert.Equal(t, "stripe", sa.GetName())
+}

--- a/internal/orchestrator/orchestrator_integration_test.go
+++ b/internal/orchestrator/orchestrator_integration_test.go
@@ -1,0 +1,329 @@
+package orchestrator_test
+
+import (
+	// "fmt" // Not used yet, but might be for error messages
+	"testing"
+	// "time" // No longer used directly
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yourorg/payment-orchestrator/internal/adapter"
+	adaptermock "github.com/yourorg/payment-orchestrator/internal/adapter/mock"
+	"github.com/yourorg/payment-orchestrator/internal/context"
+	"github.com/yourorg/payment-orchestrator/internal/orchestrator"
+	// "github.com/yourorg/payment-orchestrator/internal/policy" // No longer imported directly
+	"github.com/yourorg/payment-orchestrator/internal/router" // Using actual router
+	orchestratorinternalv1 "github.com/yourorg/payment-orchestrator/pkg/gen/protos/orchestratorinternalv1"
+	// "google.golang.org/protobuf/types/known/timestamppb" // Not used directly in these tests yet
+)
+
+// --- Mock Definitions ---
+// MockProcessor is a mock for router.ProcessorInterface
+type MockProcessor struct {
+	mock.Mock
+}
+
+func (m *MockProcessor) ProcessSingleStep(
+	ctx context.StepExecutionContext,
+	step *orchestratorinternalv1.PaymentStep,
+	adapter adapter.ProviderAdapter,
+) (*orchestratorinternalv1.StepResult, error) {
+	args := m.Called(ctx, step, adapter)
+	res, _ := args.Get(0).(*orchestratorinternalv1.StepResult)
+	return res, args.Error(1)
+}
+
+// MockPolicyEnforcer is a mock for orchestrator.PolicyEnforcerInterface
+type MockPolicyEnforcer struct {
+	mock.Mock
+}
+
+func (m *MockPolicyEnforcer) Evaluate(
+	ctx context.StepExecutionContext,
+	currentStep *orchestratorinternalv1.PaymentStep,
+	stepResult *orchestratorinternalv1.StepResult,
+) (bool, error) {
+	args := m.Called(ctx, currentStep, stepResult)
+	return args.Bool(0), args.Error(1)
+}
+
+// MockMerchantConfigRepository is a mock for context.MerchantConfigRepository
+type MockMerchantConfigRepository struct {
+	mock.Mock
+}
+
+func (m *MockMerchantConfigRepository) Get(merchantID string) (context.MerchantConfig, error) {
+	args := m.Called(merchantID) // Corrected: Method name for mock setup should match interface
+	cfg, _ := args.Get(0).(context.MerchantConfig)
+	return cfg, args.Error(1)
+}
+
+func (m *MockMerchantConfigRepository) AddConfig(config context.MerchantConfig) {
+	m.Called(config)
+}
+// --- End Mock Definitions ---
+
+// Helper to create Orchestrator with a real Router (using MockProcessor) and a MockPolicyEnforcer
+func newTestOrchestratorWithRealRouterAndMockPolicy(
+	t *testing.T,
+	mockProc *MockProcessor, // This is the local MockProcessor
+	routerCfg router.RouterConfig,
+	adapters map[string]adapter.ProviderAdapter,
+	mockPE *MockPolicyEnforcer, // This is the local MockPolicyEnforcer
+	mockMCR *MockMerchantConfigRepository,
+) *orchestrator.Orchestrator {
+	actualRouter := router.NewRouter(mockProc, adapters, routerCfg)
+	// Corrected order of arguments for NewOrchestrator
+	return orchestrator.NewOrchestrator(actualRouter, mockPE, mockMCR)
+}
+
+// Helper to create Orchestrator with MockRouter and MockPolicyEnforcer (more unit-test like for Orchestrator itself)
+// For integration, the above is preferred. This can be used if router's internal logic is not part of the test.
+// func newTestOrchestratorWithAllMocks(
+// 	t *testing.T,
+// 	mockRouter *MockRouter, // This would be orchestrator_test.MockRouter if it were in a suitable package
+// 	mockPE *MockPolicyEnforcer,
+// 	mockMCR *MockMerchantConfigRepository,
+// ) *orchestrator.Orchestrator {
+// 	return orchestrator.NewOrchestrator(mockRouter, mockPE, mockMCR)
+// }
+
+
+func TestOrchestratorIntegration_Execute_SingleStep_Success(t *testing.T) {
+	// Arrange
+	mockProcessor := new(MockProcessor)
+	mockAdapter := &adaptermock.MockAdapter{Name: "primary"} // Using the manual mock from adapter/mock
+	adapters := map[string]adapter.ProviderAdapter{"primary": mockAdapter}
+	routerCfg := router.RouterConfig{PrimaryProviderName: "primary", FallbackProviderName: "fallback"}
+
+	mockPolicyEnforcer := new(MockPolicyEnforcer)
+	mockMerchantRepo := new(MockMerchantConfigRepository)
+	// Removed expectation on mockMerchantRepo.Get as Orchestrator.Execute does not call it.
+	// The DomainContext should be provided as if it's already built.
+
+	orc := newTestOrchestratorWithRealRouterAndMockPolicy(t, mockProcessor, routerCfg, adapters, mockPolicyEnforcer, mockMerchantRepo)
+
+	step1 := &orchestratorinternalv1.PaymentStep{StepId: "step1", ProviderName: "primary", Amount: 100} // ProviderName here is a hint
+	paymentPlan := &orchestratorinternalv1.PaymentPlan{PlanId: "plan1", Steps: []*orchestratorinternalv1.PaymentStep{step1}}
+
+	traceCtx := context.NewTraceContext() // Create TraceContext separately
+	domainCtx := context.DomainContext{
+		MerchantID: "merchant1",
+		TimeoutConfig: context.TimeoutConfig{OverallBudgetMs: 5000},
+		// ActiveMerchantConfig will be fetched via mockMerchantRepo by context builder (not directly used by orchestrator's Execute)
+	}
+
+	expectedStepResult := &orchestratorinternalv1.StepResult{StepId: "step1", Success: true, ProviderName: "primary"}
+	mockProcessor.On("ProcessSingleStep", mock.AnythingOfType("context.StepExecutionContext"), step1, mockAdapter).
+		Return(expectedStepResult, nil).Once()
+	mockPolicyEnforcer.On("Evaluate", mock.AnythingOfType("context.StepExecutionContext"), step1, expectedStepResult).
+		Return(false, nil).Once() // allowRetry = false
+
+	// Act
+	result, err := orc.Execute(traceCtx, paymentPlan, domainCtx) // Pass traceCtx separately
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, "SUCCESS", result.Status)
+	require.Len(t, result.StepResults, 1)
+	assert.Equal(t, expectedStepResult, result.StepResults[0])
+	mockProcessor.AssertExpectations(t)
+	mockPolicyEnforcer.AssertExpectations(t)
+	mockMerchantRepo.AssertExpectations(t) // This will now pass as no calls are expected
+}
+
+func TestOrchestratorIntegration_Execute_MultiStep_AllSuccess(t *testing.T) {
+	mockProcessor := new(MockProcessor)
+	mockAdapterPrimary := &adaptermock.MockAdapter{Name: "primary"}
+	mockAdapterFallback := &adaptermock.MockAdapter{Name: "fallback"}
+	adapters := map[string]adapter.ProviderAdapter{"primary": mockAdapterPrimary, "fallback": mockAdapterFallback}
+	routerCfg := router.RouterConfig{PrimaryProviderName: "primary", FallbackProviderName: "fallback"}
+
+	mockPolicyEnforcer := new(MockPolicyEnforcer)
+	mockMerchantRepo := new(MockMerchantConfigRepository)
+	// Removed expectation on mockMerchantRepo.Get
+	// mockMerchantRepo.On("Get", "merchant-multi").Return(context.MerchantConfig{ID: "merchant-multi"}, nil)
+
+	orc := newTestOrchestratorWithRealRouterAndMockPolicy(t, mockProcessor, routerCfg, adapters, mockPolicyEnforcer, mockMerchantRepo)
+
+	step1 := &orchestratorinternalv1.PaymentStep{StepId: "s1", ProviderName: "primary", Amount: 100}
+	step2 := &orchestratorinternalv1.PaymentStep{StepId: "s2", ProviderName: "primary", Amount: 200} // Router will use primary for this too
+	paymentPlan := &orchestratorinternalv1.PaymentPlan{PlanId: "plan-multi", Steps: []*orchestratorinternalv1.PaymentStep{step1, step2}}
+
+	traceCtx := context.NewTraceContext() // Create TraceContext separately
+	domainCtx := context.DomainContext{
+		MerchantID: "merchant-multi",
+		TimeoutConfig: context.TimeoutConfig{OverallBudgetMs: 10000},
+	}
+
+	expectedStepResult1 := &orchestratorinternalv1.StepResult{StepId: "s1", Success: true, ProviderName: "primary"}
+	expectedStepResult2 := &orchestratorinternalv1.StepResult{StepId: "s2", Success: true, ProviderName: "primary"}
+
+	mockProcessor.On("ProcessSingleStep", mock.AnythingOfType("context.StepExecutionContext"), step1, mockAdapterPrimary).
+		Return(expectedStepResult1, nil).Once()
+	mockPolicyEnforcer.On("Evaluate", mock.AnythingOfType("context.StepExecutionContext"), step1, expectedStepResult1).
+		Return(false, nil).Once()
+
+	mockProcessor.On("ProcessSingleStep", mock.AnythingOfType("context.StepExecutionContext"), step2, mockAdapterPrimary).
+		Return(expectedStepResult2, nil).Once()
+	mockPolicyEnforcer.On("Evaluate", mock.AnythingOfType("context.StepExecutionContext"), step2, expectedStepResult2).
+		Return(false, nil).Once()
+
+	result, err := orc.Execute(traceCtx, paymentPlan, domainCtx) // Pass traceCtx separately
+
+	require.NoError(t, err)
+	assert.Equal(t, "SUCCESS", result.Status)
+	require.Len(t, result.StepResults, 2)
+	assert.Equal(t, expectedStepResult1, result.StepResults[0])
+	assert.Equal(t, expectedStepResult2, result.StepResults[1])
+	mockProcessor.AssertExpectations(t)
+	mockPolicyEnforcer.AssertExpectations(t)
+}
+
+func TestOrchestratorIntegration_Execute_StepFailure_RouterDetermined_StopsExecution(t *testing.T) {
+	// Orchestrator stops if a step fails AND policy evaluate says no retry (which is default mock for Evaluate if not set for failure)
+	// This test checks if the router returns a failure, and policy (mocked) says no retry, plan stops.
+	mockProcessor := new(MockProcessor)
+	mockAdapter := &adaptermock.MockAdapter{Name: "primary"}
+	adapters := map[string]adapter.ProviderAdapter{"primary": mockAdapter}
+	routerCfg := router.RouterConfig{PrimaryProviderName: "primary", FallbackProviderName: "fallback"}
+
+	mockPolicyEnforcer := new(MockPolicyEnforcer) // Mock policy enforcer
+	mockMerchantRepo := new(MockMerchantConfigRepository)
+	// Removed expectation on mockMerchantRepo.Get
+	// mockMerchantRepo.On("Get", "merchant-fail-stop").Return(context.MerchantConfig{ID: "merchant-fail-stop"}, nil)
+
+	orc := newTestOrchestratorWithRealRouterAndMockPolicy(t, mockProcessor, routerCfg, adapters, mockPolicyEnforcer, mockMerchantRepo)
+
+	step1 := &orchestratorinternalv1.PaymentStep{StepId: "step1-fail", ProviderName: "primary"}
+	step2 := &orchestratorinternalv1.PaymentStep{StepId: "step2-should-not-run", ProviderName: "primary"}
+	paymentPlan := &orchestratorinternalv1.PaymentPlan{PlanId: "plan-fail", Steps: []*orchestratorinternalv1.PaymentStep{step1, step2}}
+
+	traceCtx := context.NewTraceContext() // Create TraceContext separately
+	domainCtx := context.DomainContext{
+		MerchantID: "merchant-fail-stop",
+		TimeoutConfig: context.TimeoutConfig{OverallBudgetMs: 5000},
+	}
+
+	// Router's processor for primary adapter returns a failed step result
+	primaryFailedStepResult := &orchestratorinternalv1.StepResult{StepId: "step1-fail", Success: false, ProviderName: "primary", ErrorCode: "GENERIC_DECLINE"}
+	mockProcessor.On("ProcessSingleStep", mock.AnythingOfType("context.StepExecutionContext"), step1, mockAdapter).
+		Return(primaryFailedStepResult, nil).Once()
+
+	// Router then attempts fallback, but fallback adapter is not in `adapters` map for this specific test setup if we want to test this path
+	// Let's adjust: assume fallback adapter *is* present, but router's ProcessSingleStep for fallback also fails or primary failure is enough.
+	// The current router logic would attempt fallback. If fallback adapter is missing, Router returns ROUTER_CONFIGURATION_ERROR.
+	// The test failure showed it was receiving ROUTER_CONFIGURATION_ERROR for provider "fallback".
+	// This means the mockAdapter for "primary" was correctly used, and then the router tried "fallback".
+	// The test setup for adapters was: adapters := map[string]adapter.ProviderAdapter{"primary": mockAdapter}
+	// So, the fallback adapter "fallback" was indeed missing.
+
+	// Expected result from Router when fallback adapter is missing after primary failure:
+	expectedRouterOutputForEval := &orchestratorinternalv1.StepResult{
+		StepId:       "step1-fail", // from original step
+		Success:      false,
+		ProviderName: "fallback", // Router reports the provider it attempted for fallback
+		ErrorCode:    "ROUTER_CONFIGURATION_ERROR",
+		ErrorMessage: "router: fallback provider adapter 'fallback' not found",
+	}
+
+	// Policy Enforcer mock: Evaluate is called with the result from the router (which indicates fallback attempt failed)
+	mockPolicyEnforcer.On("Evaluate", mock.AnythingOfType("context.StepExecutionContext"), step1, mock.MatchedBy(func(sr *orchestratorinternalv1.StepResult) bool {
+		return sr.GetStepId() == expectedRouterOutputForEval.StepId &&
+			!sr.GetSuccess() &&
+			sr.GetProviderName() == expectedRouterOutputForEval.ProviderName &&
+			sr.GetErrorCode() == expectedRouterOutputForEval.ErrorCode
+	})).Return(false, nil).Once() // false = no retry, so orchestrator should stop
+
+	// Act
+	result, err := orc.Execute(traceCtx, paymentPlan, domainCtx) // Pass traceCtx separately
+
+	// Assert
+	require.NoError(t, err) // Orchestrator itself doesn't error for plan failures
+	assert.Equal(t, "FAILURE", result.Status)
+	require.Len(t, result.StepResults, 1) // Only the first step should have a result
+
+	actualResult := result.StepResults[0]
+	assert.Equal(t, expectedRouterOutputForEval.StepId, actualResult.StepId)
+	assert.False(t, actualResult.Success)
+	assert.Equal(t, expectedRouterOutputForEval.ProviderName, actualResult.ProviderName) // Should be "fallback"
+	assert.Equal(t, expectedRouterOutputForEval.ErrorCode, actualResult.ErrorCode)     // Should be "ROUTER_CONFIGURATION_ERROR"
+	assert.Contains(t, actualResult.ErrorMessage, "fallback provider adapter 'fallback' not found")
+
+	mockProcessor.AssertExpectations(t)
+	mockPolicyEnforcer.AssertExpectations(t)
+	// mockProcessor.AssertNotCalled(t, "ProcessSingleStep", mock.AnythingOfType("context.StepExecutionContext"), step2, mock.Anything) // step2 should not be processed
+}
+
+// TestOrchestratorIntegration_Execute_PolicyDeniesRetry_StopsExecution is effectively the same as above with MockPolicyEnforcer.
+// The distinction is subtle: router can fail a step, or policy can "fail" a step (by denying retry on a failed step).
+// The above test covers the case where router returns Success:false, and policy says "no retry".
+
+func TestOrchestratorIntegration_Execute_RouterReturnsError_StopsExecution(t *testing.T) {
+	// Test case where the router itself encounters an error (e.g., provider not configured)
+	mockProcessor := new(MockProcessor) // Will not be called if router fails before processor
+	mockAdapter := &adaptermock.MockAdapter{Name: "primary"}
+	adapters := map[string]adapter.ProviderAdapter{"primary": mockAdapter}
+	// Intentionally use a router config that will cause an error in the real router
+	routerCfg := router.RouterConfig{PrimaryProviderName: "non_existent_primary", FallbackProviderName: "fallback"}
+
+	mockPolicyEnforcer := new(MockPolicyEnforcer)
+	mockMerchantRepo := new(MockMerchantConfigRepository)
+	// mockMerchantRepo.On("Get", "merchant-router-err").Return(context.MerchantConfig{ID: "merchant-router-err"}, nil)
+
+	orc := newTestOrchestratorWithRealRouterAndMockPolicy(t, mockProcessor, routerCfg, adapters, mockPolicyEnforcer, mockMerchantRepo)
+
+	step1 := &orchestratorinternalv1.PaymentStep{StepId: "step1-router-err", ProviderName: "non_existent_primary"}
+	step2 := &orchestratorinternalv1.PaymentStep{StepId: "step2-should-not-run-router", ProviderName: "primary"}
+	paymentPlan := &orchestratorinternalv1.PaymentPlan{PlanId: "plan-router-err", Steps: []*orchestratorinternalv1.PaymentStep{step1, step2}}
+
+	traceCtx := context.NewTraceContext() // Create TraceContext separately
+	domainCtx := context.DomainContext{
+		MerchantID: "merchant-router-err",
+		TimeoutConfig: context.TimeoutConfig{OverallBudgetMs: 5000},
+	}
+
+	// Router will return an error and a StepResult indicating config error.
+	// No need to mock ProcessSingleStep on mockProcessor as router.ExecuteStep will fail before calling it.
+
+	// Policy Enforcer mock: Evaluate is still called on the error result from the router
+	// The router itself creates a StepResult when a provider is not found.
+	expectedRouterErrorResult := &orchestratorinternalv1.StepResult{
+		StepId:       "step1-router-err",
+		Success:      false,
+		ProviderName: "non_existent_primary",
+		ErrorCode:    "ROUTER_CONFIGURATION_ERROR",
+		ErrorMessage: "router: primary provider adapter 'non_existent_primary' not found",
+	}
+	// We need to use mock.MatchedBy for StepResult because its ErrorMessage might be dynamic/wrapped by router
+	mockPolicyEnforcer.On("Evaluate",
+		mock.AnythingOfType("context.StepExecutionContext"),
+		step1,
+		mock.MatchedBy(func(sr *orchestratorinternalv1.StepResult) bool {
+			return sr.GetStepId() == expectedRouterErrorResult.StepId && !sr.GetSuccess() && sr.GetErrorCode() == expectedRouterErrorResult.ErrorCode
+		}),
+	).Return(false, nil).Once() // No retry on router config error
+
+
+	result, err := orc.Execute(traceCtx, paymentPlan, domainCtx) // Pass traceCtx separately
+
+	require.NoError(t, err) // Orchestrator itself does not error, the plan fails.
+	assert.Equal(t, "FAILURE", result.Status)
+	require.Len(t, result.StepResults, 1) // Only the first step attempted
+
+	actualResult := result.StepResults[0]
+	assert.Equal(t, expectedRouterErrorResult.StepId, actualResult.StepId)
+	assert.False(t, actualResult.Success)
+	assert.Equal(t, expectedRouterErrorResult.ProviderName, actualResult.ProviderName)
+	assert.Equal(t, expectedRouterErrorResult.ErrorCode, actualResult.ErrorCode)
+	// ErrorMessage from router might have more details, so Contains is safer.
+	assert.Contains(t, actualResult.ErrorMessage, "primary provider adapter 'non_existent_primary' not found")
+
+	mockProcessor.AssertNotCalled(t, "ProcessSingleStep", mock.Anything, mock.Anything, mock.Anything)
+	mockPolicyEnforcer.AssertExpectations(t)
+}
+
+// TODO: Add test for PolicyEnforcer returning an error during Evaluate.
+// TODO: Add test for a step failing but policy allows retry (plan still fails overall for now, but all steps should be attempted unless a prior failure caused a hard stop).

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -5,43 +5,74 @@ import (
 	// "time" // Removed
 
 	"github.com/yourorg/payment-orchestrator/internal/context"
-	"github.com/yourorg/payment-orchestrator/internal/policy"
+	// "github.com/yourorg/payment-orchestrator/internal/policy" // Will use mock interface
 	internalv1 "github.com/yourorg/payment-orchestrator/pkg/gen/protos/orchestratorinternalv1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	// "github.com/google/uuid" // Removed
 )
 
-// MockMerchantConfigRepository (MockPolicyEnforcer removed as we'll use the real one for now)
-type MockMerchantConfigRepository struct {
-    cfg context.MerchantConfig
-    err error
+// MockRouter is a mock implementation of RouterInterface
+type MockRouter struct {
+	mock.Mock
 }
+
+func (m *MockRouter) ExecuteStep(ctx context.StepExecutionContext, step *internalv1.PaymentStep) (*internalv1.StepResult, error) {
+	args := m.Called(ctx, step)
+	res, _ := args.Get(0).(*internalv1.StepResult)
+	return res, args.Error(1)
+}
+
+// MockPolicyEnforcer is a mock implementation of PolicyEnforcerInterface
+type MockPolicyEnforcer struct {
+	mock.Mock
+}
+
+func (m *MockPolicyEnforcer) Evaluate(ctx context.StepExecutionContext, currentStep *internalv1.PaymentStep, stepResult *internalv1.StepResult) (bool, error) {
+	args := m.Called(ctx, currentStep, stepResult)
+	return args.Bool(0), args.Error(1)
+}
+
+// MockMerchantConfigRepository
+type MockMerchantConfigRepository struct {
+	cfg context.MerchantConfig
+	err error
+}
+
 func (m *MockMerchantConfigRepository) Get(merchantID string) (context.MerchantConfig, error) {
-    if m.err != nil {
-        return context.MerchantConfig{}, m.err
-    }
-    cfgWithID := m.cfg
-    cfgWithID.ID = merchantID // Ensure the returned config has the requested ID
-    return cfgWithID, nil
+	if m.err != nil {
+		return context.MerchantConfig{}, m.err
+	}
+	cfgWithID := m.cfg
+	cfgWithID.ID = merchantID // Ensure the returned config has the requested ID
+	return cfgWithID, nil
 }
 func (m *MockMerchantConfigRepository) AddConfig(config context.MerchantConfig) { /* not used in this test */ }
 
 
 func TestNewOrchestrator(t *testing.T) {
-	pe := policy.NewPaymentPolicyEnforcer() // Use actual policy enforcer
-	mcr := &MockMerchantConfigRepository{}
-	orc := NewOrchestrator(pe, mcr)
-	assert.NotNil(t, orc)
-	assert.Equal(t, pe, orc.policyEnforcer) // This will compare pointers
-	assert.Equal(t, mcr, orc.merchantConfigRepo)
+	mockRouter := new(MockRouter)
+	mockPolicyEnforcer := new(MockPolicyEnforcer)
+	mockMcr := new(MockMerchantConfigRepository)
 
-	assert.Panics(t, func() { NewOrchestrator(nil, mcr) }, "Should panic if policy enforcer is nil")
-	assert.Panics(t, func() { NewOrchestrator(pe, nil) }, "Should panic if merchant config repo is nil")
+	orc := NewOrchestrator(mockRouter, mockPolicyEnforcer, mockMcr)
+	assert.NotNil(t, orc)
+	assert.Equal(t, mockRouter, orc.router)
+	assert.Equal(t, mockPolicyEnforcer, orc.policyEnforcer)
+	assert.Equal(t, mockMcr, orc.merchantConfigRepo)
+
+	assert.Panics(t, func() { NewOrchestrator(nil, mockPolicyEnforcer, mockMcr) }, "Should panic if router is nil")
+	assert.Panics(t, func() { NewOrchestrator(mockRouter, nil, mockMcr) }, "Should panic if policy enforcer is nil")
+	assert.Panics(t, func() { NewOrchestrator(mockRouter, mockPolicyEnforcer, nil) }, "Should panic if merchant config repo is nil")
 }
 
 func TestOrchestrator_Execute_EmptyPlan(t *testing.T) {
-	orc := NewOrchestrator(policy.NewPaymentPolicyEnforcer(), &MockMerchantConfigRepository{})
+	mockRouter := new(MockRouter)
+	mockPolicyEnforcer := new(MockPolicyEnforcer)
+	mockMcr := new(MockMerchantConfigRepository)
+	orc := NewOrchestrator(mockRouter, mockPolicyEnforcer, mockMcr)
+
 	traceCtx := context.NewTraceContext()
 	domainCtx := context.DomainContext{}
 
@@ -61,113 +92,131 @@ func TestOrchestrator_Execute_EmptyPlan(t *testing.T) {
 	assert.Equal(t, "FAILURE", result.Status)
 }
 
-func TestOrchestrator_Execute_SingleStepPlan_Stubbed(t *testing.T) {
-	realPE := policy.NewPaymentPolicyEnforcer() // Use actual policy enforcer
+func TestOrchestrator_Execute_SingleStepPlan_Success(t *testing.T) {
+	mockRouter := new(MockRouter)
+	mockPolicyEnforcer := new(MockPolicyEnforcer)
 	mockMCR := &MockMerchantConfigRepository{
-	    cfg: context.MerchantConfig{DefaultProvider: "stripe", ProviderAPIKeys: map[string]string{"stripe":"testkey"}},
+		cfg: context.MerchantConfig{DefaultProvider: "stripe", ProviderAPIKeys: map[string]string{"stripe": "testkey"}},
 	}
-	orc := NewOrchestrator(realPE, mockMCR)
+	orc := NewOrchestrator(mockRouter, mockPolicyEnforcer, mockMCR)
 
 	traceCtx := context.NewTraceContext()
 	domainCtx := context.DomainContext{
-		MerchantID: "merchant1",
-		TimeoutConfig: context.TimeoutConfig{OverallBudgetMs: 5000},
+		MerchantID:           "merchant1",
+		TimeoutConfig:        context.TimeoutConfig{OverallBudgetMs: 5000},
 		ActiveMerchantConfig: mockMCR.cfg,
 	}
+	step1 := &internalv1.PaymentStep{StepId: "step1", ProviderName: "stripe", Amount: 1000, Currency: "USD", Metadata: make(map[string]string), ProviderPayload: make(map[string]string)}
 	plan := &internalv1.PaymentPlan{
 		PlanId: "plan-single-step",
-		Steps: []*internalv1.PaymentStep{
-			{StepId: "step1", ProviderName: "stripe", Amount: 1000, Currency: "USD", Metadata: make(map[string]string), ProviderPayload: make(map[string]string)},
-		},
+		Steps:  []*internalv1.PaymentStep{step1},
 	}
+
+	// Mock expectations
+	expectedStepResult1 := &internalv1.StepResult{StepId: "step1", Success: true, ProviderName: "stripe"}
+	mockRouter.On("ExecuteStep", mock.AnythingOfType("context.StepExecutionContext"), step1).Return(expectedStepResult1, nil).Once()
+	mockPolicyEnforcer.On("Evaluate", mock.AnythingOfType("context.StepExecutionContext"), step1, expectedStepResult1).Return(false, nil).Once() // allowRetry = false
 
 	result, err := orc.Execute(traceCtx, plan, domainCtx)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
 	assert.NotEmpty(t, result.PaymentID)
-	assert.Equal(t, "SUCCESS", result.Status, "Overall status should be SUCCESS for stubbed execution")
+	assert.Equal(t, "SUCCESS", result.Status)
 	require.Len(t, result.StepResults, 1)
+	assert.Equal(t, expectedStepResult1, result.StepResults[0])
 
-	stepResult1 := result.StepResults[0]
-	assert.Equal(t, "step1", stepResult1.StepId)
-	assert.True(t, stepResult1.Success, "Stubbed step should be successful")
-	assert.Equal(t, "stripe", stepResult1.ProviderName)
-	assert.Empty(t, stepResult1.ErrorCode)
-	assert.NotNil(t, stepResult1.Details)
-	assert.Equal(t, "success", stepResult1.Details["stubbed_result"])
+	mockRouter.AssertExpectations(t)
+	mockPolicyEnforcer.AssertExpectations(t)
 }
 
-func TestOrchestrator_Execute_MultiStepPlan_Stubbed(t *testing.T) {
-	realPE := policy.NewPaymentPolicyEnforcer() // Use actual policy enforcer
+func TestOrchestrator_Execute_MultiStepPlan_AllSuccess(t *testing.T) { // Renamed from _Stubbed
+	mockRouter := new(MockRouter)
+	mockPolicyEnforcer := new(MockPolicyEnforcer)
 	mockMCR := &MockMerchantConfigRepository{
-	    cfg: context.MerchantConfig{DefaultProvider: "stripe", ProviderAPIKeys: map[string]string{"stripe":"testkey", "adyen":"testkey2"}},
+		cfg: context.MerchantConfig{DefaultProvider: "stripe", ProviderAPIKeys: map[string]string{"stripe": "testkey", "adyen": "testkey2"}},
 	}
-	orc := NewOrchestrator(realPE, mockMCR)
+	orc := NewOrchestrator(mockRouter, mockPolicyEnforcer, mockMCR)
+
 	traceCtx := context.NewTraceContext()
 	domainCtx := context.DomainContext{
-		MerchantID: "merchant2",
-		TimeoutConfig: context.TimeoutConfig{OverallBudgetMs: 10000},
+		MerchantID:           "merchant2",
+		TimeoutConfig:        context.TimeoutConfig{OverallBudgetMs: 10000},
 		ActiveMerchantConfig: mockMCR.cfg,
 	}
+	step1 := &internalv1.PaymentStep{StepId: "s1", ProviderName: "stripe", Amount: 500, Currency: "EUR", Metadata: make(map[string]string), ProviderPayload: make(map[string]string)}
+	step2 := &internalv1.PaymentStep{StepId: "s2", ProviderName: "adyen", Amount: 700, Currency: "EUR", Metadata: make(map[string]string), ProviderPayload: make(map[string]string)}
 	plan := &internalv1.PaymentPlan{
 		PlanId: "plan-multi-step",
-		Steps: []*internalv1.PaymentStep{
-			{StepId: "s1", ProviderName: "stripe", Amount: 500, Currency: "EUR", Metadata: make(map[string]string), ProviderPayload: make(map[string]string)},
-			{StepId: "s2", ProviderName: "adyen", Amount: 700, Currency: "EUR", Metadata: make(map[string]string), ProviderPayload: make(map[string]string)},
-		},
+		Steps:  []*internalv1.PaymentStep{step1, step2},
 	}
+
+	// Mock expectations
+	expectedStepResult1 := &internalv1.StepResult{StepId: "s1", Success: true, ProviderName: "stripe"}
+	expectedStepResult2 := &internalv1.StepResult{StepId: "s2", Success: true, ProviderName: "adyen"}
+	mockRouter.On("ExecuteStep", mock.AnythingOfType("context.StepExecutionContext"), step1).Return(expectedStepResult1, nil).Once()
+	mockPolicyEnforcer.On("Evaluate", mock.AnythingOfType("context.StepExecutionContext"), step1, expectedStepResult1).Return(false, nil).Once()
+	mockRouter.On("ExecuteStep", mock.AnythingOfType("context.StepExecutionContext"), step2).Return(expectedStepResult2, nil).Once()
+	mockPolicyEnforcer.On("Evaluate", mock.AnythingOfType("context.StepExecutionContext"), step2, expectedStepResult2).Return(false, nil).Once()
+
 
 	result, err := orc.Execute(traceCtx, plan, domainCtx)
 	require.NoError(t, err)
 	assert.Equal(t, "SUCCESS", result.Status)
 	require.Len(t, result.StepResults, 2)
+	assert.Equal(t, expectedStepResult1, result.StepResults[0])
+	assert.Equal(t, expectedStepResult2, result.StepResults[1])
 
-	assert.Equal(t, "s1", result.StepResults[0].StepId)
-	assert.True(t, result.StepResults[0].Success)
-	assert.Equal(t, "stripe", result.StepResults[0].ProviderName)
-	assert.NotNil(t, result.StepResults[0].Details)
-
-	assert.Equal(t, "s2", result.StepResults[1].StepId)
-	assert.True(t, result.StepResults[1].Success)
-	assert.Equal(t, "adyen", result.StepResults[1].ProviderName)
-	assert.NotNil(t, result.StepResults[1].Details)
+	mockRouter.AssertExpectations(t)
+	mockPolicyEnforcer.AssertExpectations(t)
 }
 
 func TestOrchestrator_Execute_HandlesNilStepInPlan(t *testing.T) {
-	realPE := policy.NewPaymentPolicyEnforcer() // Use actual policy enforcer
+	mockRouter := new(MockRouter)
+	mockPolicyEnforcer := new(MockPolicyEnforcer)
 	mockMCR := &MockMerchantConfigRepository{
-	    cfg: context.MerchantConfig{DefaultProvider: "stripe"},
+		cfg: context.MerchantConfig{DefaultProvider: "stripe", ProviderAPIKeys: map[string]string{"stripe": "testkey", "adyen": "testkey2"}},
 	}
-	orc := NewOrchestrator(realPE, mockMCR)
+	orc := NewOrchestrator(mockRouter, mockPolicyEnforcer, mockMCR)
+
 	traceCtx := context.NewTraceContext()
 	domainCtx := context.DomainContext{
-		MerchantID: "merchant-nil-step",
-		TimeoutConfig: context.TimeoutConfig{OverallBudgetMs: 10000},
+		MerchantID:           "merchant-nil-step",
+		TimeoutConfig:        context.TimeoutConfig{OverallBudgetMs: 10000},
 		ActiveMerchantConfig: mockMCR.cfg,
 	}
+	step1 := &internalv1.PaymentStep{StepId: "s1", ProviderName: "stripe", Amount: 500, Currency: "EUR", Metadata: make(map[string]string), ProviderPayload: make(map[string]string)}
+	step3 := &internalv1.PaymentStep{StepId: "s3", ProviderName: "adyen", Amount: 700, Currency: "EUR", Metadata: make(map[string]string), ProviderPayload: make(map[string]string)}
 	plan := &internalv1.PaymentPlan{
 		PlanId: "plan-with-nil-step",
-		Steps: []*internalv1.PaymentStep{
-			{StepId: "s1", ProviderName: "stripe", Amount: 500, Currency: "EUR", Metadata: make(map[string]string), ProviderPayload: make(map[string]string)},
-			nil, // A nil step
-			{StepId: "s3", ProviderName: "adyen", Amount: 700, Currency: "EUR", Metadata: make(map[string]string), ProviderPayload: make(map[string]string)},
-		},
+		Steps:  []*internalv1.PaymentStep{step1, nil, step3},
 	}
 
+	// Mock expectations for non-nil steps
+	expectedStepResult1 := &internalv1.StepResult{StepId: "s1", Success: true, ProviderName: "stripe"}
+	expectedStepResult3 := &internalv1.StepResult{StepId: "s3", Success: true, ProviderName: "adyen"}
+
+	mockRouter.On("ExecuteStep", mock.AnythingOfType("context.StepExecutionContext"), step1).Return(expectedStepResult1, nil).Once()
+	mockPolicyEnforcer.On("Evaluate", mock.AnythingOfType("context.StepExecutionContext"), step1, expectedStepResult1).Return(false, nil).Once()
+	// No router/policy calls for nil step
+	mockRouter.On("ExecuteStep", mock.AnythingOfType("context.StepExecutionContext"), step3).Return(expectedStepResult3, nil).Once()
+	mockPolicyEnforcer.On("Evaluate", mock.AnythingOfType("context.StepExecutionContext"), step3, expectedStepResult3).Return(false, nil).Once()
+
+
 	result, err := orc.Execute(traceCtx, plan, domainCtx)
-	require.NoError(t, err) // The main Execute function doesn't return an error for this case
+	require.NoError(t, err) // The main Execute function doesn't return an error for this specific case of nil step in plan
 	assert.Equal(t, "FAILURE", result.Status, "Overall status should be FAILURE due to nil step")
 	require.Len(t, result.StepResults, 3)
 
-	assert.Equal(t, "s1", result.StepResults[0].StepId)
-	assert.True(t, result.StepResults[0].Success)
+	assert.Equal(t, expectedStepResult1, result.StepResults[0]) // s1 is processed
 
+	// Check the result for the nil step
 	assert.False(t, result.StepResults[1].Success, "Nil step should result in a failure StepResult")
 	assert.Equal(t, "NIL_STEP", result.StepResults[1].ErrorCode)
-	assert.Equal(t, "nil-step-1", result.StepResults[1].StepId)
+	assert.Equal(t, "nil-step-1", result.StepResults[1].StepId) // ID generated by orchestrator
 
+	assert.Equal(t, expectedStepResult3, result.StepResults[2]) // s3 is processed after nil
 
-	assert.Equal(t, "s3", result.StepResults[2].StepId)
-	assert.True(t, result.StepResults[2].Success) // Subsequent steps are still stubbed as success
+	mockRouter.AssertExpectations(t)
+	mockPolicyEnforcer.AssertExpectations(t)
 }

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -1,0 +1,86 @@
+package processor
+
+import (
+	"log" // Using standard log for now
+
+	"github.com/yourorg/payment-orchestrator/internal/adapter"
+	"github.com/yourorg/payment-orchestrator/internal/context"
+	orchestratorinternalv1 "github.com/yourorg/payment-orchestrator/pkg/gen/protos/orchestratorinternalv1"
+	// timestamppb is not needed as StepResult does not have a timestamp field
+)
+
+// Processor handles the execution of a single payment step by invoking the appropriate provider adapter.
+type Processor struct {
+	// logger can be added here if a more sophisticated logger is introduced.
+	// For now, we'll use the standard `log` package.
+}
+
+// NewProcessor creates a new instance of the Processor.
+func NewProcessor() *Processor {
+	return &Processor{}
+}
+
+// ProcessSingleStep instructs a given provider adapter to process a payment step.
+// It takes the step-specific execution context, the payment step details, and the adapter to use.
+// It returns the result of the step execution and any error encountered.
+func (p *Processor) ProcessSingleStep(
+	ctx context.StepExecutionContext,
+	step *orchestratorinternalv1.PaymentStep,
+	providerAdapter adapter.ProviderAdapter,
+) (*orchestratorinternalv1.StepResult, error) {
+	log.Printf("Processor: Starting ProcessSingleStep for StepID: %s, Provider: %s", step.GetStepId(), step.GetProviderName())
+
+	// Construct TraceContext for the adapter
+	traceCtxForAdapter := context.TraceContext{
+		TraceID: ctx.TraceID,
+		SpanID:  ctx.SpanID,
+	}
+
+	// Delegate the actual processing to the adapter
+	adapterResult, err := providerAdapter.Process(traceCtxForAdapter, step, ctx)
+
+	// Convert adapter.ProviderResult to orchestratorinternalv1.StepResult
+	stepResultDetails := make(map[string]string)
+	if adapterResult.TransactionID != "" {
+		stepResultDetails["provider_transaction_id"] = adapterResult.TransactionID
+	}
+	// Potentially copy other details from adapterResult.Details to stepResultDetails if needed
+
+	stepResult := &orchestratorinternalv1.StepResult{
+		StepId:        adapterResult.StepID, // Should match step.GetStepId()
+		ProviderName:  step.GetProviderName(), // The provider that was intended to be used for this step
+		Success:       adapterResult.Success,
+		ErrorCode:     adapterResult.ErrorCode,
+		ErrorMessage:  adapterResult.ErrorMessage,
+		LatencyMs:     adapterResult.LatencyMs, // Assuming ProviderResult has LatencyMs
+		Details:       stepResultDetails,
+	}
+
+	if err != nil {
+		log.Printf("Processor: Error processing StepID %s with Provider %s: %v", step.GetStepId(), step.GetProviderName(), err)
+		stepResult.Success = false
+		// Ensure ErrorCode and ErrorMessage from the error are prioritized if adapterResult didn't set them well
+		if stepResult.ErrorCode == "" {
+			stepResult.ErrorCode = "PROCESSOR_EXECUTION_ERROR" // Generic processor error
+		}
+		if stepResult.ErrorMessage == "" {
+			stepResult.ErrorMessage = err.Error()
+		}
+		return stepResult, err // Return the original error
+	}
+
+	// If no error, adapterResult.Success is the source of truth for success status
+	// ErrorCode and ErrorMessage from adapterResult are already mapped.
+	// If !adapterResult.Success but err is nil, ensure ErrorCode/Msg are populated.
+	if !stepResult.Success {
+		if stepResult.ErrorCode == "" {
+			stepResult.ErrorCode = "PROVIDER_OPERATION_FAILED"
+		}
+		if stepResult.ErrorMessage == "" {
+			stepResult.ErrorMessage = "Provider indicated failure without a specific error message."
+		}
+	}
+
+	log.Printf("Processor: Finished ProcessSingleStep for StepID %s, Provider: %s, Success: %t", step.GetStepId(), step.GetProviderName(), stepResult.GetSuccess())
+	return stepResult, nil
+}

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -1,0 +1,178 @@
+package processor_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	// "github.com/stretchr/testify/mock" // No longer needed for manual mock
+
+	"github.com/yourorg/payment-orchestrator/internal/adapter"
+	adaptermock "github.com/yourorg/payment-orchestrator/internal/adapter/mock"
+	"github.com/yourorg/payment-orchestrator/internal/context"
+	"github.com/yourorg/payment-orchestrator/internal/processor"
+	orchestratorinternalv1 "github.com/yourorg/payment-orchestrator/pkg/gen/protos/orchestratorinternalv1"
+	// timestamppb is no longer needed
+)
+
+func TestProcessor_ProcessSingleStep(t *testing.T) {
+	t.Run("Successful payment processing", func(t *testing.T) {
+		// Arrange
+		mockAdapter := new(adaptermock.MockAdapter) // Use correct mock
+		proc := processor.NewProcessor()
+
+		baseTraceID := "trace-123"
+		stepSpanID := "span-step-123"
+		stepCtx := context.StepExecutionContext{
+			TraceID:           baseTraceID,
+			SpanID:            stepSpanID,
+			StartTime:         time.Now(),
+			RemainingBudgetMs: 10000,
+			// ProviderCredentials would be set here in a real scenario
+		}
+		expectedTraceCtxForAdapter := context.TraceContext{TraceID: baseTraceID, SpanID: stepSpanID}
+
+		paymentStep := &orchestratorinternalv1.PaymentStep{
+			StepId:       "step-abc",
+			ProviderName: "test-provider",
+			Amount:       1000,
+			Currency:     "USD",
+			// PaymentMethod: orchestratorinternalv1.PaymentMethod_PAYMENT_METHOD_CREDIT_CARD, // This field does not exist on PaymentStep
+		}
+		adapterResponse := adapter.ProviderResult{
+			StepID:        "step-abc",
+			Success:       true,
+			TransactionID: "prov123",
+			Provider:      "test-provider",
+		}
+
+		var processFuncCalled bool
+		mockAdapter.ProcessFunc = func(tc context.TraceContext, step *orchestratorinternalv1.PaymentStep, sc context.StepExecutionContext) (adapter.ProviderResult, error) {
+			processFuncCalled = true
+			assert.Equal(t, expectedTraceCtxForAdapter, tc)
+			assert.Equal(t, paymentStep, step)
+			assert.Equal(t, stepCtx, sc)
+			return adapterResponse, nil
+		}
+
+		// Act
+		result, err := proc.ProcessSingleStep(stepCtx, paymentStep, mockAdapter)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.True(t, processFuncCalled, "Adapter's ProcessFunc was not called")
+		assert.NotNil(t, result)
+		assert.Equal(t, "step-abc", result.GetStepId())
+		assert.True(t, result.GetSuccess())
+		assert.Equal(t, "test-provider", result.GetProviderName())
+		assert.Equal(t, "prov123", result.GetDetails()["provider_transaction_id"])
+		assert.Empty(t, result.GetErrorCode())
+		assert.Empty(t, result.GetErrorMessage())
+	})
+
+	t.Run("Failed payment processing (adapter returns an error)", func(t *testing.T) {
+		// Arrange
+		mockAdapter := new(adaptermock.MockAdapter) // Use correct mock
+		proc := processor.NewProcessor()
+
+		baseTraceID := "trace-456"
+		stepSpanID := "span-step-456"
+		stepCtx := context.StepExecutionContext{
+			TraceID:           baseTraceID,
+			SpanID:            stepSpanID,
+			StartTime:         time.Now(),
+			RemainingBudgetMs: 9000,
+		}
+		expectedTraceCtxForAdapter := context.TraceContext{TraceID: baseTraceID, SpanID: stepSpanID}
+
+		paymentStep := &orchestratorinternalv1.PaymentStep{
+			StepId:       "step-def",
+			ProviderName: "test-provider-fail",
+			Amount:       2000,
+			Currency:     "EUR",
+			// PaymentMethod: orchestratorinternalv1.PaymentMethod_PAYMENT_METHOD_BANK_TRANSFER, // This field does not exist on PaymentStep
+		}
+		expectedAdapterError := errors.New("provider processing error")
+		adapterResponse := adapter.ProviderResult{
+			StepID:       "step-def",
+			Success:      false,
+			Provider:     "test-provider-fail",
+			ErrorCode:    "PROVIDER_DOWN",
+			ErrorMessage: "The provider experienced an internal issue.",
+		}
+
+		var processFuncCalled bool
+		mockAdapter.ProcessFunc = func(tc context.TraceContext, step *orchestratorinternalv1.PaymentStep, sc context.StepExecutionContext) (adapter.ProviderResult, error) {
+			processFuncCalled = true
+			assert.Equal(t, expectedTraceCtxForAdapter, tc)
+			// It's good practice to assert relevant parts of step and sc if they are critical for the mock's behavior
+			return adapterResponse, expectedAdapterError
+		}
+
+		// Act
+		result, err := proc.ProcessSingleStep(stepCtx, paymentStep, mockAdapter)
+
+		// Assert
+		assert.Error(t, err)
+		assert.True(t, processFuncCalled, "Adapter's ProcessFunc was not called")
+		assert.Equal(t, expectedAdapterError, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "step-def", result.GetStepId())
+		assert.False(t, result.GetSuccess())
+		assert.Equal(t, "test-provider-fail", result.GetProviderName())
+		assert.Equal(t, "PROVIDER_DOWN", result.GetErrorCode())    // ErrorCode from adapterResult
+		assert.Equal(t, "The provider experienced an internal issue.", result.GetErrorMessage()) // ErrorMessage from adapterResult
+	})
+
+	t.Run("Failed payment processing (adapter returns success:false, no error)", func(t *testing.T) {
+		// Arrange
+		mockAdapter := new(adaptermock.MockAdapter)
+		proc := processor.NewProcessor()
+
+		baseTraceID := "trace-789"
+		stepSpanID := "span-step-789"
+		stepCtx := context.StepExecutionContext{
+			TraceID:           baseTraceID,
+			SpanID:            stepSpanID,
+			StartTime:         time.Now(),
+			RemainingBudgetMs: 8000,
+		}
+		expectedTraceCtxForAdapter := context.TraceContext{TraceID: baseTraceID, SpanID: stepSpanID}
+
+		paymentStep := &orchestratorinternalv1.PaymentStep{
+			StepId:       "step-ghi",
+			ProviderName: "test-provider-reject",
+			Amount:       3000,
+			Currency:     "GBP",
+			// PaymentMethod: orchestratorinternalv1.PaymentMethod_PAYMENT_METHOD_IDEAL, // This field does not exist on PaymentStep
+		}
+		adapterResponse := adapter.ProviderResult{
+			StepID:       "step-ghi",
+			Success:      false, // Explicitly false
+			Provider:     "test-provider-reject",
+			ErrorCode:    "CARD_DECLINED",
+			ErrorMessage: "Card was declined by issuer.",
+		}
+
+		var processFuncCalled bool
+		mockAdapter.ProcessFunc = func(tc context.TraceContext, step *orchestratorinternalv1.PaymentStep, sc context.StepExecutionContext) (adapter.ProviderResult, error) {
+			processFuncCalled = true
+			assert.Equal(t, expectedTraceCtxForAdapter, tc) // Added assertion for consistency
+			return adapterResponse, nil // No error returned by adapter
+		}
+
+		// Act
+		result, err := proc.ProcessSingleStep(stepCtx, paymentStep, mockAdapter)
+
+		// Assert
+		assert.NoError(t, err) // No error from ProcessSingleStep itself
+		assert.True(t, processFuncCalled, "Adapter's ProcessFunc was not called")
+		assert.NotNil(t, result)
+		assert.Equal(t, "step-ghi", result.GetStepId())
+		assert.False(t, result.GetSuccess())
+		assert.Equal(t, "test-provider-reject", result.GetProviderName())
+		assert.Equal(t, "CARD_DECLINED", result.GetErrorCode())
+		assert.Equal(t, "Card was declined by issuer.", result.GetErrorMessage())
+	})
+}

--- a/internal/router/circuitbreaker/circuitbreaker.go
+++ b/internal/router/circuitbreaker/circuitbreaker.go
@@ -1,0 +1,187 @@
+package circuitbreaker
+
+import (
+	"sync"
+	"time"
+)
+
+// State represents the state of the circuit breaker.
+type State int
+
+const (
+	// StateClosed allows requests to pass through.
+	StateClosed State = iota
+	// StateOpen blocks requests.
+	StateOpen
+	// StateHalfOpen allows a limited number of test requests.
+	StateHalfOpen
+)
+
+// String makes State satisfy the Stringer interface for easier logging.
+func (s State) String() string {
+	switch s {
+	case StateClosed:
+		return "Closed"
+	case StateOpen:
+		return "Open"
+	case StateHalfOpen:
+		return "HalfOpen"
+	default:
+		return "Unknown"
+	}
+}
+
+// providerState holds the current state of a specific provider in the circuit breaker.
+type providerState struct {
+	name                string
+	currentState        State
+	consecutiveFailures int
+	lastFailureTime     time.Time
+	openTime            time.Time // When the circuit was last opened
+}
+
+// Config stores the configuration for the CircuitBreaker.
+type Config struct {
+	FailureThreshold     int           // Number of consecutive failures to open the circuit.
+	ResetTimeout         time.Duration // Time after which an Open circuit transitions to HalfOpen.
+	// HalfOpenSuccessThreshold int // Future: How many successes in half-open to close. For now, 1 success closes.
+}
+
+// CircuitBreaker implements the circuit breaker pattern for multiple providers.
+type CircuitBreaker struct {
+	providerStates map[string]*providerState
+	config         Config
+	mu             sync.RWMutex // Protects access to providerStates map
+}
+
+// NewCircuitBreaker creates a new CircuitBreaker with the given configuration.
+// It sets default values if parts of the config are zero.
+func NewCircuitBreaker(config Config) *CircuitBreaker {
+	if config.FailureThreshold <= 0 {
+		config.FailureThreshold = 3 // Default to 3 consecutive failures
+	}
+	if config.ResetTimeout <= 0 {
+		config.ResetTimeout = 30 * time.Second // Default to 30 seconds
+	}
+	return &CircuitBreaker{
+		providerStates: make(map[string]*providerState),
+		config:         config,
+	}
+}
+
+// getProviderState retrieves or creates a default (Closed) state for a provider.
+// This internal helper must be called with the write lock (cb.mu.Lock()) held.
+func (cb *CircuitBreaker) getProviderState(providerName string) *providerState {
+	ps, exists := cb.providerStates[providerName]
+	if !exists {
+		ps = &providerState{
+			name:                providerName,
+			currentState:        StateClosed,
+			consecutiveFailures: 0,
+		}
+		cb.providerStates[providerName] = ps
+	}
+	return ps
+}
+
+// AllowRequest checks if a request to the given provider should be allowed based on the circuit state.
+// It may transition the state from Open to HalfOpen if ResetTimeout has passed.
+func (cb *CircuitBreaker) AllowRequest(providerName string) bool {
+	cb.mu.Lock() // Lock for potential state modification (Open -> HalfOpen)
+	defer cb.mu.Unlock()
+
+	ps := cb.getProviderState(providerName) // Ensures state exists
+
+	switch ps.currentState {
+	case StateClosed:
+		return true
+	case StateOpen:
+		if time.Since(ps.openTime) > cb.config.ResetTimeout {
+			// Log.Printf("CircuitBreaker: Provider '%s' transitioning from Open to HalfOpen after timeout.", providerName)
+			ps.currentState = StateHalfOpen
+			ps.consecutiveFailures = 0 // Reset for half-open test
+			return true               // Allow one request in half-open
+		}
+		return false // Still Open, within timeout
+	case StateHalfOpen:
+		// Log.Printf("CircuitBreaker: Provider '%s' is HalfOpen, allowing test request.", providerName)
+		return true // Allow the test request
+	default:
+		// Log.Printf("CircuitBreaker: Provider '%s' in unknown state %v, defaulting to allow.", providerName, ps.currentState)
+		return true // Should not happen
+	}
+}
+
+// RecordSuccess records a successful request for the provider.
+// It can transition the state from HalfOpen to Closed.
+func (cb *CircuitBreaker) RecordSuccess(providerName string) {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	ps, exists := cb.providerStates[providerName]
+	if !exists {
+		// If no state exists, it implies AllowRequest was never called or it was for a new provider.
+		// A success for an unknown/untracked provider doesn't need to change any state.
+		// Or, we could create a state here, but typically AllowRequest would be called first.
+		// Log.Printf("CircuitBreaker: RecordSuccess for untracked provider '%s'. No action taken.", providerName)
+		return
+	}
+
+	if ps.currentState == StateHalfOpen {
+		// Log.Printf("CircuitBreaker: Provider '%s' transitioning from HalfOpen to Closed after success.", providerName)
+		ps.currentState = StateClosed
+		ps.consecutiveFailures = 0
+	} else if ps.currentState == StateClosed {
+		// If there were some sporadic failures that didn't meet the threshold, a success resets the count.
+		if ps.consecutiveFailures > 0 {
+			// Log.Printf("CircuitBreaker: Provider '%s' in Closed state, resetting consecutiveFailures from %d to 0 after success.", providerName, ps.consecutiveFailures)
+			ps.consecutiveFailures = 0
+		}
+	}
+	// No change if Open (successes during Open state are ignored until it transitions to HalfOpen)
+}
+
+// RecordFailure records a failed request for the provider.
+// It can transition the state from Closed to Open, or HalfOpen to Open.
+func (cb *CircuitBreaker) RecordFailure(providerName string) {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	// Use getProviderState to ensure state exists, as a failure might be recorded
+	// even if AllowRequest wasn't called (e.g., timeout before request could be blocked).
+	ps := cb.getProviderState(providerName)
+	ps.lastFailureTime = time.Now()
+
+	if ps.currentState == StateHalfOpen {
+		// Log.Printf("CircuitBreaker: Provider '%s' transitioning from HalfOpen to Open after failure.", providerName)
+		ps.currentState = StateOpen
+		ps.openTime = time.Now()
+		// consecutiveFailures is already reset when entering HalfOpen, one failure is enough to re-open.
+		// We can set it to threshold to ensure it stays open for the full timeout.
+		ps.consecutiveFailures = cb.config.FailureThreshold
+	} else if ps.currentState == StateClosed {
+		ps.consecutiveFailures++
+		// Log.Printf("CircuitBreaker: Provider '%s' in Closed state, consecutiveFailures incremented to %d.", providerName, ps.consecutiveFailures)
+		if ps.consecutiveFailures >= cb.config.FailureThreshold {
+			// Log.Printf("CircuitBreaker: Provider '%s' transitioning from Closed to Open after %d failures.", providerName, ps.consecutiveFailures)
+			ps.currentState = StateOpen
+			ps.openTime = time.Now()
+		}
+	}
+	// No change if already Open and not yet timed out for HalfOpen attempt.
+	// If it was Open and timed out, AllowRequest would have moved it to HalfOpen,
+	// and this failure would move it back to Open as per the HalfOpen case above.
+}
+
+// GetProviderStatus is a helper to inspect the state (for testing or monitoring).
+// Not part of the core CB logic for processing, but useful.
+func (cb *CircuitBreaker) GetProviderStatus(providerName string) (State, int) {
+	cb.mu.RLock() // Use RLock for read-only access
+	defer cb.mu.RUnlock()
+
+	ps, exists := cb.providerStates[providerName]
+	if !exists {
+		return StateClosed, 0 // Default for unknown provider
+	}
+	return ps.currentState, ps.consecutiveFailures
+}

--- a/internal/router/circuitbreaker/circuitbreaker_test.go
+++ b/internal/router/circuitbreaker/circuitbreaker_test.go
@@ -1,0 +1,241 @@
+package circuitbreaker_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yourorg/payment-orchestrator/internal/router/circuitbreaker"
+)
+
+const (
+	testProvider = "test-provider"
+	anotherProvider = "another-provider"
+)
+
+func TestNewCircuitBreaker(t *testing.T) {
+	t.Run("Default config", func(t *testing.T) {
+		cfg := circuitbreaker.Config{}
+		cb := circuitbreaker.NewCircuitBreaker(cfg)
+		require.NotNil(t, cb)
+		// Accessing private config fields for assertion is not direct.
+		// We can test behavior that depends on defaults.
+		// For example, it should take 3 failures by default to open.
+		assert.True(t, cb.AllowRequest(testProvider), "Should allow by default")
+		cb.RecordFailure(testProvider)
+		cb.RecordFailure(testProvider)
+		assert.True(t, cb.AllowRequest(testProvider), "Should still be closed after 2 failures")
+		cb.RecordFailure(testProvider)
+		assert.False(t, cb.AllowRequest(testProvider), "Should be open after 3 failures with default config")
+	})
+
+	t.Run("Custom config", func(t *testing.T) {
+		cfg := circuitbreaker.Config{
+			FailureThreshold: 2,
+			ResetTimeout:     100 * time.Millisecond,
+		}
+		cb := circuitbreaker.NewCircuitBreaker(cfg)
+		require.NotNil(t, cb)
+		cb.RecordFailure(testProvider)
+		assert.True(t, cb.AllowRequest(testProvider), "Should still be closed after 1 failure")
+		cb.RecordFailure(testProvider)
+		assert.False(t, cb.AllowRequest(testProvider), "Should be open after 2 failures with custom config")
+	})
+}
+
+func TestCircuitBreaker_StateTransitions(t *testing.T) {
+	cfg := circuitbreaker.Config{
+		FailureThreshold:     2,
+		ResetTimeout:         50 * time.Millisecond, // Short for testing
+	}
+
+	t.Run("Closed_To_Open", func(t *testing.T) {
+		cb := circuitbreaker.NewCircuitBreaker(cfg)
+
+		// Initial state: Closed
+		assert.True(t, cb.AllowRequest(testProvider), "Should be initially Closed and allow requests")
+		state, failures := cb.GetProviderStatus(testProvider)
+		assert.Equal(t, circuitbreaker.StateClosed, state)
+		assert.Equal(t, 0, failures)
+
+		// Record failures to meet threshold
+		cb.RecordFailure(testProvider) // Failure 1
+		state, failures = cb.GetProviderStatus(testProvider)
+		assert.Equal(t, circuitbreaker.StateClosed, state)
+		assert.Equal(t, 1, failures)
+		assert.True(t, cb.AllowRequest(testProvider), "Still Closed after 1 failure")
+
+		cb.RecordFailure(testProvider) // Failure 2 - Threshold met
+		state, failures = cb.GetProviderStatus(testProvider)
+		assert.Equal(t, circuitbreaker.StateOpen, state, "Should transition to Open")
+		assert.Equal(t, cfg.FailureThreshold, failures) // Failures should be at threshold
+		assert.False(t, cb.AllowRequest(testProvider), "Should be Open and block requests")
+	})
+
+	t.Run("Open_To_HalfOpen", func(t *testing.T) {
+		cb := circuitbreaker.NewCircuitBreaker(cfg)
+		// Trip to Open state
+		cb.RecordFailure(testProvider)
+		cb.RecordFailure(testProvider)
+		require.False(t, cb.AllowRequest(testProvider), "Pre-condition: Should be Open")
+		state, _ := cb.GetProviderStatus(testProvider)
+		require.Equal(t, circuitbreaker.StateOpen, state)
+
+		// Wait for ResetTimeout
+		time.Sleep(cfg.ResetTimeout + 10*time.Millisecond)
+
+		assert.True(t, cb.AllowRequest(testProvider), "Should allow request (transition to HalfOpen)")
+		state, failures := cb.GetProviderStatus(testProvider)
+		assert.Equal(t, circuitbreaker.StateHalfOpen, state, "State should be HalfOpen")
+		assert.Equal(t, 0, failures, "Consecutive failures should reset in HalfOpen")
+	})
+
+	t.Run("HalfOpen_To_Closed_OnSuccess", func(t *testing.T) {
+		cb := circuitbreaker.NewCircuitBreaker(cfg)
+		// Trip to Open, then wait for HalfOpen
+		cb.RecordFailure(testProvider)
+		cb.RecordFailure(testProvider)
+		time.Sleep(cfg.ResetTimeout + 10*time.Millisecond)
+		require.True(t, cb.AllowRequest(testProvider), "Should allow request in HalfOpen") // This moves to HalfOpen
+		state, _ := cb.GetProviderStatus(testProvider)
+		require.Equal(t, circuitbreaker.StateHalfOpen, state, "Pre-condition: Should be HalfOpen")
+
+		// Record success
+		cb.RecordSuccess(testProvider)
+		state, failures := cb.GetProviderStatus(testProvider)
+		assert.Equal(t, circuitbreaker.StateClosed, state, "Should transition to Closed after success in HalfOpen")
+		assert.Equal(t, 0, failures, "Failures should be reset")
+		assert.True(t, cb.AllowRequest(testProvider), "Should allow requests in Closed state")
+	})
+
+	t.Run("HalfOpen_To_Open_OnFailure", func(t *testing.T) {
+		cb := circuitbreaker.NewCircuitBreaker(cfg)
+		// Trip to Open, then wait for HalfOpen
+		cb.RecordFailure(testProvider)
+		cb.RecordFailure(testProvider)
+		time.Sleep(cfg.ResetTimeout + 10*time.Millisecond)
+		require.True(t, cb.AllowRequest(testProvider), "Should allow request in HalfOpen") // Moves to HalfOpen
+		state, _ := cb.GetProviderStatus(testProvider)
+		require.Equal(t, circuitbreaker.StateHalfOpen, state, "Pre-condition: Should be HalfOpen")
+
+		// Record failure
+		cb.RecordFailure(testProvider)
+		state, failures := cb.GetProviderStatus(testProvider)
+		assert.Equal(t, circuitbreaker.StateOpen, state, "Should transition back to Open after failure in HalfOpen")
+		// Failures set to threshold to keep it open for full timeout
+		assert.Equal(t, cfg.FailureThreshold, failures, "Failures should be set to threshold")
+		assert.False(t, cb.AllowRequest(testProvider), "Should block requests in Open state")
+
+		// Check if it stays Open and doesn't immediately go to HalfOpen again
+		time.Sleep(cfg.ResetTimeout / 2)
+		assert.False(t, cb.AllowRequest(testProvider), "Should still be Open before ResetTimeout passes again")
+	})
+}
+
+func TestCircuitBreaker_FailuresBelowThreshold(t *testing.T) {
+	cfg := circuitbreaker.Config{FailureThreshold: 3}
+	cb := circuitbreaker.NewCircuitBreaker(cfg)
+
+	cb.RecordFailure(testProvider)
+	state, failures := cb.GetProviderStatus(testProvider)
+	assert.Equal(t, circuitbreaker.StateClosed, state)
+	assert.Equal(t, 1, failures)
+	assert.True(t, cb.AllowRequest(testProvider))
+
+	cb.RecordFailure(testProvider)
+	state, failures = cb.GetProviderStatus(testProvider)
+	assert.Equal(t, circuitbreaker.StateClosed, state)
+	assert.Equal(t, 2, failures)
+	assert.True(t, cb.AllowRequest(testProvider))
+
+	// Success should reset failures
+	cb.RecordSuccess(testProvider)
+	state, failures = cb.GetProviderStatus(testProvider)
+	assert.Equal(t, circuitbreaker.StateClosed, state)
+	assert.Equal(t, 0, failures)
+	assert.True(t, cb.AllowRequest(testProvider))
+}
+
+func TestCircuitBreaker_MultipleProviders(t *testing.T) {
+	cfg := circuitbreaker.Config{FailureThreshold: 1, ResetTimeout: 50 * time.Millisecond}
+	cb := circuitbreaker.NewCircuitBreaker(cfg)
+
+	// Provider 1 fails and opens
+	cb.RecordFailure(testProvider)
+	assert.False(t, cb.AllowRequest(testProvider), "Provider1 should be Open")
+
+	// Provider 2 should still be Closed
+	assert.True(t, cb.AllowRequest(anotherProvider), "Provider2 should be Closed and allow requests")
+	cb.RecordFailure(anotherProvider)
+	assert.False(t, cb.AllowRequest(anotherProvider), "Provider2 should now be Open")
+
+	// Provider 1 should still be Open
+	assert.False(t, cb.AllowRequest(testProvider), "Provider1 should still be Open")
+
+	// Wait for Provider 1 to go HalfOpen
+	time.Sleep(cfg.ResetTimeout + 10*time.Millisecond)
+	assert.True(t, cb.AllowRequest(testProvider), "Provider1 should be HalfOpen")
+	cb.RecordSuccess(testProvider)
+	assert.True(t, cb.AllowRequest(testProvider), "Provider1 should be Closed")
+
+	// Provider 2 should still be Open (its timeout hasn't necessarily passed if it opened later)
+	// or could be HalfOpen if its timeout also passed.
+	// Let's ensure its timeout also passes to check its independent transition.
+	time.Sleep(cfg.ResetTimeout + 10*time.Millisecond)
+	assert.True(t, cb.AllowRequest(anotherProvider), "Provider2 should also be HalfOpen after its timeout")
+	cb.RecordSuccess(anotherProvider)
+	assert.True(t, cb.AllowRequest(anotherProvider), "Provider2 should be Closed")
+}
+
+func TestCircuitBreaker_Idempotency(t *testing.T) {
+	cfg := circuitbreaker.Config{FailureThreshold: 1}
+	cb := circuitbreaker.NewCircuitBreaker(cfg)
+
+	// Idempotency of RecordFailure in Closed state (leading to Open)
+	cb.RecordFailure(testProvider) // Transitions to Open
+	state, failures := cb.GetProviderStatus(testProvider)
+	assert.Equal(t, circuitbreaker.StateOpen, state)
+	assert.Equal(t, 1, failures)
+
+	cb.RecordFailure(testProvider) // Should not change anything further if already Open and failures at threshold
+	state, failures = cb.GetProviderStatus(testProvider)
+	assert.Equal(t, circuitbreaker.StateOpen, state)
+	assert.Equal(t, 1, failures) // Stays at threshold
+
+	// Idempotency of RecordSuccess in Closed state
+	cb.RecordSuccess(anotherProvider) // Assuming anotherProvider is new, becomes Closed, 0 failures
+	state, failures = cb.GetProviderStatus(anotherProvider)
+	assert.Equal(t, circuitbreaker.StateClosed, state)
+	assert.Equal(t, 0, failures)
+	cb.RecordSuccess(anotherProvider) // Should remain Closed, 0 failures
+	state, failures = cb.GetProviderStatus(anotherProvider)
+	assert.Equal(t, circuitbreaker.StateClosed, state)
+	assert.Equal(t, 0, failures)
+}
+
+func TestCircuitBreaker_AllowRequest_CreatesState(t *testing.T) {
+    cb := circuitbreaker.NewCircuitBreaker(circuitbreaker.Config{})
+    assert.True(t, cb.AllowRequest("new-provider"))
+    state, failures := cb.GetProviderStatus("new-provider")
+    assert.Equal(t, circuitbreaker.StateClosed, state)
+    assert.Equal(t, 0, failures)
+}
+
+func TestCircuitBreaker_RecordSuccess_UntrackedProvider(t *testing.T) {
+    cb := circuitbreaker.NewCircuitBreaker(circuitbreaker.Config{})
+    cb.RecordSuccess("untracked-provider") // Should not panic, should be a no-op or log
+    state, failures := cb.GetProviderStatus("untracked-provider")
+    // Depending on implementation of GetProviderStatus for truly untracked (vs created on demand by getProviderState)
+    // Current getProviderState in RecordFailure creates it. If RecordSuccess doesn't, it would be default.
+    // The current RecordSuccess bails if state doesn't exist.
+    assert.Equal(t, circuitbreaker.StateClosed, state) // GetProviderStatus creates a default Closed state if not found
+    assert.Equal(t, 0, failures)
+}
+
+func TestCircuitBreaker_State_String(t *testing.T) {
+	assert.Equal(t, "Closed", circuitbreaker.StateClosed.String())
+	assert.Equal(t, "Open", circuitbreaker.StateOpen.String())
+	assert.Equal(t, "HalfOpen", circuitbreaker.StateHalfOpen.String())
+	assert.Equal(t, "Unknown", circuitbreaker.State(99).String())
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,0 +1,111 @@
+package router
+
+import (
+	"fmt"
+	"log" // Using standard log for now
+
+	"github.com/yourorg/payment-orchestrator/internal/adapter"
+	"github.com/yourorg/payment-orchestrator/internal/context"
+	// "github.com/yourorg/payment-orchestrator/internal/processor" // Not directly used by router struct, but by ProcessorInterface
+	orchestratorinternalv1 "github.com/yourorg/payment-orchestrator/pkg/gen/protos/orchestratorinternalv1"
+)
+
+// RouterConfig holds the configuration for the router's provider selection logic.
+type RouterConfig struct {
+	PrimaryProviderName  string
+	FallbackProviderName string
+}
+
+// ProcessorInterface defines the contract for processing a single payment step.
+// This allows for mocking the processor in router tests.
+type ProcessorInterface interface {
+	ProcessSingleStep(
+		ctx context.StepExecutionContext,
+		step *orchestratorinternalv1.PaymentStep,
+		adapter adapter.ProviderAdapter,
+	) (*orchestratorinternalv1.StepResult, error)
+}
+
+// Router is responsible for selecting a payment provider and executing a payment step.
+// It currently implements a simple primary/fallback logic.
+type Router struct {
+	processor ProcessorInterface
+	adapters  map[string]adapter.ProviderAdapter
+	config    RouterConfig
+	// logger    *log.Logger // Example for a more structured logger
+}
+
+// NewRouter creates a new Router instance.
+func NewRouter(
+	processor ProcessorInterface,
+	adapters map[string]adapter.ProviderAdapter,
+	config RouterConfig,
+) *Router {
+	return &Router{
+		processor: processor,
+		adapters:  adapters,
+		config:    config,
+	}
+}
+
+// ExecuteStep attempts to process a payment step using a primary provider,
+// and falls back to a secondary provider if the primary attempt fails.
+func (r *Router) ExecuteStep(
+	ctx context.StepExecutionContext,
+	step *orchestratorinternalv1.PaymentStep,
+) (*orchestratorinternalv1.StepResult, error) {
+	log.Printf("Router: Starting ExecuteStep for StepID: %s, Original Provider in Step: %s", step.GetStepId(), step.GetProviderName())
+
+	// Attempt with Primary Provider
+	primaryAdapter, ok := r.adapters[r.config.PrimaryProviderName]
+	if !ok {
+		err := fmt.Errorf("router: primary provider adapter '%s' not found", r.config.PrimaryProviderName)
+		log.Printf("Router: Error - %v", err)
+		// Return a StepResult indicating failure due to configuration error
+		return &orchestratorinternalv1.StepResult{
+			StepId:       step.GetStepId(),
+			Success:      false,
+			ProviderName: r.config.PrimaryProviderName, // The one we attempted to use
+			ErrorCode:    "ROUTER_CONFIGURATION_ERROR",
+			ErrorMessage: err.Error(),
+		}, err
+	}
+
+	log.Printf("Router: Attempting StepID %s with primary provider: %s", step.GetStepId(), r.config.PrimaryProviderName)
+	// Update step's provider name to reflect the one being used by the router for this attempt
+	// This is important if the original step.ProviderName was a generic hint or empty.
+	// However, the processor will also set ProviderName in the result based on the adapter it used.
+	// For clarity, we can log which provider the router *intends* to use.
+	// The actual step.ProviderName field might be more of an input preference.
+	// Let's assume the processor correctly sets ProviderName in the StepResult.
+
+	result, err := r.processor.ProcessSingleStep(ctx, step, primaryAdapter)
+
+	if err != nil || (result != nil && !result.GetSuccess()) {
+		log.Printf("Router: Primary provider %s failed for StepID %s. Error: %v, ResultSuccess: %t. Attempting fallback.",
+			r.config.PrimaryProviderName, step.GetStepId(), err, result != nil && result.GetSuccess())
+
+		fallbackAdapter, ok := r.adapters[r.config.FallbackProviderName]
+		if !ok {
+			fallbackErr := fmt.Errorf("router: fallback provider adapter '%s' not found", r.config.FallbackProviderName)
+			log.Printf("Router: Error - %v", fallbackErr)
+			// Return a StepResult indicating failure due to configuration error
+			// We return the original error/result from primary if that's more informative,
+			// or this new configuration error. The spec implies returning the fallback's outcome.
+			// If primary failed and fallback config is missing, this is a critical router/config issue.
+			return &orchestratorinternalv1.StepResult{
+				StepId:       step.GetStepId(),
+				Success:      false,
+				ProviderName: r.config.FallbackProviderName, // The one we attempted to use
+				ErrorCode:    "ROUTER_CONFIGURATION_ERROR",
+				ErrorMessage: fallbackErr.Error(),
+			}, fallbackErr // Return the fallback config error
+		}
+
+		log.Printf("Router: Attempting StepID %s with fallback provider: %s", step.GetStepId(), r.config.FallbackProviderName)
+		return r.processor.ProcessSingleStep(ctx, step, fallbackAdapter)
+	}
+
+	log.Printf("Router: Primary provider %s succeeded for StepID %s.", r.config.PrimaryProviderName, step.GetStepId())
+	return result, err
+}

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -1,0 +1,171 @@
+package router_test
+
+import (
+	"errors"
+	// "fmt" // No longer needed
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/yourorg/payment-orchestrator/internal/adapter"
+	adaptermock "github.com/yourorg/payment-orchestrator/internal/adapter/mock" // Using existing manual mock for adapters
+	"github.com/yourorg/payment-orchestrator/internal/context"
+	"github.com/yourorg/payment-orchestrator/internal/router"
+	orchestratorinternalv1 "github.com/yourorg/payment-orchestrator/pkg/gen/protos/orchestratorinternalv1"
+)
+
+// MockProcessor is a mock implementation of the router.ProcessorInterface using testify/mock.
+type MockProcessor struct {
+	mock.Mock
+}
+
+func (m *MockProcessor) ProcessSingleStep(
+	ctx context.StepExecutionContext,
+	step *orchestratorinternalv1.PaymentStep,
+	adapter adapter.ProviderAdapter,
+) (*orchestratorinternalv1.StepResult, error) {
+	args := m.Called(ctx, step, adapter)
+	res, _ := args.Get(0).(*orchestratorinternalv1.StepResult)
+	return res, args.Error(1)
+}
+
+func TestRouter_ExecuteStep(t *testing.T) {
+	mockPrimaryAdapter := &adaptermock.MockAdapter{Name: "primary"}
+	mockFallbackAdapter := &adaptermock.MockAdapter{Name: "fallback"}
+
+	mockAdapters := map[string]adapter.ProviderAdapter{
+		"primary":  mockPrimaryAdapter,
+		"fallback": mockFallbackAdapter,
+	}
+
+	defaultRouterConfig := router.RouterConfig{
+		PrimaryProviderName:  "primary",
+		FallbackProviderName: "fallback",
+	}
+
+	dummyStepCtx := context.StepExecutionContext{
+		TraceID:           "test-trace",
+		SpanID:            "test-span",
+		StartTime:         time.Now(),
+		RemainingBudgetMs: 10000,
+	}
+	dummyPaymentStep := &orchestratorinternalv1.PaymentStep{
+		StepId:       "step-123",
+		ProviderName: "any", // Router should override this based on its config
+		Amount:       100,
+		Currency:     "USD",
+	}
+
+	t.Run("Primary provider succeeds", func(t *testing.T) {
+		mockProcessor := new(MockProcessor)
+		routerInstance := router.NewRouter(mockProcessor, mockAdapters, defaultRouterConfig)
+
+		expectedResult := &orchestratorinternalv1.StepResult{Success: true, ProviderName: "primary", StepId: "step-123"}
+		mockProcessor.On("ProcessSingleStep", dummyStepCtx, dummyPaymentStep, mockPrimaryAdapter).
+			Return(expectedResult, nil).Once()
+
+		result, err := routerInstance.ExecuteStep(dummyStepCtx, dummyPaymentStep)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expectedResult, result)
+		mockProcessor.AssertExpectations(t)
+	})
+
+	t.Run("Primary fails, Fallback succeeds", func(t *testing.T) {
+		mockProcessor := new(MockProcessor)
+		routerInstance := router.NewRouter(mockProcessor, mockAdapters, defaultRouterConfig)
+
+		primaryResult := &orchestratorinternalv1.StepResult{Success: false, ProviderName: "primary", StepId: "step-123"}
+		fallbackExpectedResult := &orchestratorinternalv1.StepResult{Success: true, ProviderName: "fallback", StepId: "step-123"}
+
+		mockProcessor.On("ProcessSingleStep", dummyStepCtx, dummyPaymentStep, mockPrimaryAdapter).
+			Return(primaryResult, nil).Once()
+		mockProcessor.On("ProcessSingleStep", dummyStepCtx, dummyPaymentStep, mockFallbackAdapter).
+			Return(fallbackExpectedResult, nil).Once()
+
+		result, err := routerInstance.ExecuteStep(dummyStepCtx, dummyPaymentStep)
+
+		assert.NoError(t, err)
+		assert.Equal(t, fallbackExpectedResult, result)
+		mockProcessor.AssertExpectations(t)
+	})
+
+	t.Run("Primary fails (with error), Fallback succeeds", func(t *testing.T) {
+		mockProcessor := new(MockProcessor)
+		routerInstance := router.NewRouter(mockProcessor, mockAdapters, defaultRouterConfig)
+
+		primaryResult := &orchestratorinternalv1.StepResult{Success: false, ProviderName: "primary", ErrorCode: "PRIMARY_ERR", StepId: "step-123"}
+		primaryError := errors.New("primary provider error")
+		fallbackExpectedResult := &orchestratorinternalv1.StepResult{Success: true, ProviderName: "fallback", StepId: "step-123"}
+
+		mockProcessor.On("ProcessSingleStep", dummyStepCtx, dummyPaymentStep, mockPrimaryAdapter).
+			Return(primaryResult, primaryError).Once()
+		mockProcessor.On("ProcessSingleStep", dummyStepCtx, dummyPaymentStep, mockFallbackAdapter).
+			Return(fallbackExpectedResult, nil).Once()
+
+		result, err := routerInstance.ExecuteStep(dummyStepCtx, dummyPaymentStep)
+
+		assert.NoError(t, err) // Fallback succeeded, so overall error should be nil
+		assert.Equal(t, fallbackExpectedResult, result)
+		mockProcessor.AssertExpectations(t)
+	})
+
+	t.Run("Primary fails, Fallback fails", func(t *testing.T) {
+		mockProcessor := new(MockProcessor)
+		routerInstance := router.NewRouter(mockProcessor, mockAdapters, defaultRouterConfig)
+
+		primaryResult := &orchestratorinternalv1.StepResult{Success: false, ProviderName: "primary", StepId: "step-123"}
+		fallbackResult := &orchestratorinternalv1.StepResult{Success: false, ProviderName: "fallback", ErrorCode: "FALLBACK_ERR", StepId: "step-123"}
+		fallbackError := errors.New("fallback provider error")
+
+		mockProcessor.On("ProcessSingleStep", dummyStepCtx, dummyPaymentStep, mockPrimaryAdapter).
+			Return(primaryResult, nil).Once()
+		mockProcessor.On("ProcessSingleStep", dummyStepCtx, dummyPaymentStep, mockFallbackAdapter).
+			Return(fallbackResult, fallbackError).Once()
+
+		result, err := routerInstance.ExecuteStep(dummyStepCtx, dummyPaymentStep)
+
+		assert.Error(t, err)
+		assert.Equal(t, fallbackError, err)
+		assert.Equal(t, fallbackResult, result)
+		mockProcessor.AssertExpectations(t)
+	})
+
+	t.Run("Primary provider adapter not found", func(t *testing.T) {
+		mockProcessor := new(MockProcessor) // Processor won't be called
+		badConfig := router.RouterConfig{PrimaryProviderName: "nonexistent", FallbackProviderName: "fallback"}
+		routerInstance := router.NewRouter(mockProcessor, mockAdapters, badConfig)
+
+		result, err := routerInstance.ExecuteStep(dummyStepCtx, dummyPaymentStep)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "primary provider adapter 'nonexistent' not found")
+		assert.NotNil(t, result)
+		assert.False(t, result.GetSuccess())
+		assert.Equal(t, "ROUTER_CONFIGURATION_ERROR", result.GetErrorCode())
+		assert.Equal(t, "nonexistent", result.GetProviderName()) // Shows which provider was attempted
+		mockProcessor.AssertNotCalled(t, "ProcessSingleStep", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("Fallback provider adapter not found (after primary fails)", func(t *testing.T) {
+		mockProcessor := new(MockProcessor)
+		badFallbackConfig := router.RouterConfig{PrimaryProviderName: "primary", FallbackProviderName: "nonexistent"}
+		routerInstance := router.NewRouter(mockProcessor, mockAdapters, badFallbackConfig)
+
+		primaryResult := &orchestratorinternalv1.StepResult{Success: false, ProviderName: "primary", StepId: "step-123"}
+		mockProcessor.On("ProcessSingleStep", dummyStepCtx, dummyPaymentStep, mockPrimaryAdapter).
+			Return(primaryResult, nil).Once()
+
+		result, err := routerInstance.ExecuteStep(dummyStepCtx, dummyPaymentStep)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "fallback provider adapter 'nonexistent' not found")
+		assert.NotNil(t, result)
+		assert.False(t, result.GetSuccess())
+		assert.Equal(t, "ROUTER_CONFIGURATION_ERROR", result.GetErrorCode())
+		assert.Equal(t, "nonexistent", result.GetProviderName()) // Shows which provider was attempted for fallback
+		mockProcessor.AssertExpectations(t) // Primary was called
+	})
+}

--- a/todo.md
+++ b/todo.md
@@ -8,120 +8,120 @@ This `todo.md` tracks which implementation steps have been completed (☑) and w
 ## Chunk 1: Project & CI Setup
 
 1. **Repository Initialization**  
-   - [ ] Create new Git repository `payment-orchestrator`.  
-   - [ ] Initialize Go module: `go mod init github.com/yourorg/payment-orchestrator`.  
-   - [ ] Create folder structure (`cmd/server/main.go`, `internal/...`, `pkg/gen/`, `schemas/`).  
-   - [ ] Add `Makefile` with targets: `gen`, `lint`, `test`.  
-   - [ ] Add GitHub Actions CI at `.github/workflows/ci.yml` to run `make gen`, `make lint`, `make test`.
+   - [☑] Create new Git repository `payment-orchestrator`.
+   - [☑] Initialize Go module: `go mod init github.com/yourorg/payment-orchestrator`.
+   - [☑] Create folder structure (`cmd/server/main.go`, `internal/...`, `pkg/gen/`, `schemas/`).  *(Note: `schemas/` is `protos/`)*
+   - [☑] Add `Makefile` with targets: `gen`, `lint`, `test`.
+   - [☑] Add GitHub Actions CI at `.github/workflows/ci.yml` to run `make gen`, `make lint`, `make test`.
 
 ---
 
 ## Chunk 2: Schema Definition & Code Generation
 
 2. **External Schema**  
-   - [ ] Create `schemas/external/v1/external_request.proto`.  
+   - [☑] Create `schemas/external/v1/external_request.proto`. *(Note: Path is `protos/orchestratorexternalv1/external_request.proto`)*
 
 3. **Internal Schemas**  
-   - [ ] Create `schemas/internal/v1/payment_plan.proto`.  
-   - [ ] Create `schemas/internal/v1/payment_step.proto`.  
-   - [ ] Create `schemas/internal/v1/step_result.proto`.  
+   - [☑] Create `schemas/internal/v1/payment_plan.proto`. *(Note: Path is `protos/orchestratorinternalv1/payment_plan.proto`)*
+   - [☑] Create `schemas/internal/v1/payment_step.proto`. *(Note: Path is `protos/orchestratorinternalv1/payment_step.proto`)*
+   - [☑] Create `schemas/internal/v1/step_result.proto`. *(Note: Path is `protos/orchestratorinternalv1/step_result.proto`)*
 
 4. **Buf Configuration**  
-   - [ ] Add `buf.yaml` at project root.  
-   - [ ] Run `buf generate` and verify generated Go code under `pkg/gen/`.  
+   - [☑] Add `buf.yaml` at project root.
+   - [☑] Run `buf generate` and verify generated Go code under `pkg/gen/`.
 
 ---
 
 ## Chunk 3: Context & Dual Boundary
 
 5. **TraceContext**  
-   - [ ] Create `internal/context/trace.go` with `TraceContext` and `NewTraceContext()`.  
+   - [☑] Create `internal/context/trace.go` with `TraceContext` and `NewTraceContext()`.
 
 6. **DomainContext**  
-   - [ ] Create `internal/context/domain.go` with `DomainContext` and `BuildDomainContext()`.  
-   - [ ] Define stubs for `TimeoutConfig`, `RetryPolicy`, `MerchantConfig`.
+   - [☑] Create `internal/context/domain.go` with `DomainContext` and `BuildDomainContext()`.
+   - [☑] Define stubs for `TimeoutConfig`, `RetryPolicy`, `MerchantConfig`.
 
 7. **StepExecutionContext**  
-   - [ ] Create `internal/context/step.go` with `StepExecutionContext` and `DeriveStepCtx()`.  
+   - [☑] Create `internal/context/step.go` with `StepExecutionContext` and `DeriveStepCtx()`.
 
 8. **Context Builder**  
-   - [ ] Create `internal/context/builder.go` with `BuildContexts(ext, merchantCfg)`.  
-   - [ ] Write tests in `internal/context/builder_test.go`.
+   - [☑] Create `internal/context/builder.go` with `BuildContexts(ext, merchantCfg)`.
+   - [☑] Write tests in `internal/context/builder_test.go`.
 
 ---
 
 ## Chunk 4: PlanBuilder (Basic) & Composite Stub
 
 9. **PlanBuilder (Naive)**  
-   - [ ] Create `internal/planbuilder/planbuilder.go` with `PlanBuilder.Build()` returning a single-step plan.  
-   - [ ] Define `MerchantConfig` type (with `DefaultProvider`, `DefaultAmount`, `DefaultCurrency`).  
-   - [ ] Write tests in `internal/planbuilder/planbuilder_test.go`.
+   - [☑] Create `internal/planbuilder/planbuilder.go` with `PlanBuilder.Build()` returning a single-step plan.
+   - [☑] Define `MerchantConfig` type (with `DefaultProvider`, `DefaultAmount`, `DefaultCurrency`). *(Note: `DefaultAmount` sourced from request)*
+   - [☑] Write tests in `internal/planbuilder/planbuilder_test.go`.
 
 10. **CompositePaymentService (Stub)**  
-    - [ ] Create `internal/planbuilder/composite.go` with `CompositePaymentService.Optimize()` returning input plan.  
-    - [ ] Write tests in `internal/planbuilder/composite_test.go`.  
-    - [ ] Integrate `Optimize` call into `PlanBuilder.Build()`.
+    - [☑] Create `internal/planbuilder/composite.go` with `CompositePaymentService.Optimize()` returning input plan.
+    - [☑] Write tests in `internal/planbuilder/composite_test.go`.
+    - [☑] Integrate `Optimize` call into `PlanBuilder.Build()`.
 
 ---
 
 ## Chunk 5: PaymentPolicyEnforcer (Basic)
 
 11. **Policy Enforcer Stub**  
-    - [ ] Create `internal/policy/policy.go` with `PaymentPolicyEnforcer.Evaluate()` always allowing retry.  
-    - [ ] Write tests in `internal/policy/policy_test.go`.
+    - [☑] Create `internal/policy/policy.go` with `PaymentPolicyEnforcer.Evaluate()` always allowing retry.
+    - [☑] Write tests in `internal/policy/policy_test.go`.
 
 ---
 
 ## Chunk 6: Orchestrator (Placeholder ExecuteStep)
 
 12. **Orchestrator Skeleton**  
-    - [ ] Create `internal/orchestrator/orchestrator.go` with `Orchestrator.Execute()` looping over steps and returning success stubs.  
-    - [ ] Write tests in `internal/orchestrator/orchestrator_test.go`.
+    - [☑] Create `internal/orchestrator/orchestrator.go` with `Orchestrator.Execute()` looping over steps and returning success stubs.
+    - [☑] Write tests in `internal/orchestrator/orchestrator_test.go`.
 
 ---
 
 ## Chunk 7: ProviderAdapter Interface & Mock Adapter
 
 13. **Adapter Interface**  
-    - [ ] Create `internal/adapter/adapter.go` defining `ProviderAdapter`.  
+    - [☑] Create `internal/adapter/adapter.go` defining `ProviderAdapter`.
 
 14. **MockAdapter**  
-    - [ ] Create `internal/adapter/mock/mock_adapter.go` implementing `MockAdapter`.  
-    - [ ] Write tests in `internal/adapter/mock/mock_adapter_test.go`.
+    - [☑] Create `internal/adapter/mock/mock_adapter.go` implementing `MockAdapter`.
+    - [☑] Write tests in `internal/adapter/mock/mock_adapter_test.go`.
 
 ---
 
 ## Chunk 8: Processor Layer
 
 15. **Processor Implementation**  
-    - [ ] Create `internal/processor/processor.go` with `Processor.ProcessSingleStep()`, wrapping `ProviderAdapter`.  
-    - [ ] Write tests in `internal/processor/processor_test.go`.
+    - [☑] Create `internal/processor/processor.go` with `Processor.ProcessSingleStep()`, wrapping `ProviderAdapter`.
+    - [☑] Write tests in `internal/processor/processor_test.go`.
 
 ---
 
 ## Chunk 9: Router (Minimal Fallback)
 
 16. **Router Skeleton**  
-    - [ ] Create `internal/router/router.go` with simple fallback logic (primary + fallback chain).  
-    - [ ] Write tests in `internal/router/router_test.go`.
+    - [☑] Create `internal/router/router.go` with simple fallback logic (primary + fallback chain).
+    - [☑] Write tests in `internal/router/router_test.go`.
 
 ---
 
 ## Chunk 10: Orchestrator (Integrate Router & Policy)
 
 17. **Orchestrator Integration**  
-    - [ ] Update `internal/orchestrator/orchestrator.go` to call `Router.ExecuteStep()` and respect policy.  
-    - [ ] Modify `NewOrchestrator()` to accept a `Router`.  
-    - [ ] Write integration tests in `internal/orchestrator/orchestrator_integration_test.go`.
+    - [☑] Update `internal/orchestrator/orchestrator.go` to call `Router.ExecuteStep()` and respect policy.
+    - [☑] Modify `NewOrchestrator()` to accept a `Router`.
+    - [☑] Write integration tests in `internal/orchestrator/orchestrator_integration_test.go`.
 
 ---
 
 ## Chunk 11: StripeAdapter (Simple Implementation)
 
 18. **StripeAdapter**  
-    - [ ] Create `internal/adapter/stripe/stripe_adapter.go` with HTTP calls and retry logic.  
-    - [ ] Implement helpers: `buildStripePayload()`, `generateIdempotencyKey()`.  
-    - [ ] Write tests in `internal/adapter/stripe/stripe_adapter_test.go` using `httptest.Server`.
+    - [☑] Create `internal/adapter/stripe/stripe_adapter.go` with HTTP calls and retry logic.
+    - [☑] Implement helpers: `buildStripePayload()`, `generateIdempotencyKey()`.
+    - [☑] Write tests in `internal/adapter/stripe/stripe_adapter_test.go` using `httptest.Server`.
 
 ---
 


### PR DESCRIPTION
This commit introduces the Circuit Breaker service.

Key changes:

`internal/router/circuitbreaker/circuitbreaker.go`:
- Created the `circuitbreaker` package.
- Defined `State` enum (`StateClosed`, `StateOpen`, `StateHalfOpen`) with a `String()` method for readability.
- Defined `providerState` struct to store individual provider status:
    - `currentState State`
    - `consecutiveFailures int`
    - `lastFailureTime time.Time`
    - `openTime time.Time` (when the circuit was last opened)
- Defined `Config` struct for `FailureThreshold` and `ResetTimeout` with default values.
- Implemented the `CircuitBreaker` struct, containing:
    - `providerStates map[string]*providerState`: In-memory store for provider states.
    - `config Config`: Circuit breaker configuration.
    - `mu sync.RWMutex`: For thread-safe access to `providerStates`.
- Implemented `NewCircuitBreaker(config Config)` constructor.
- Implemented core methods:
    - `AllowRequest(providerName string) bool`: Checks if a request is allowed for a provider. Handles state transitions from Open to HalfOpen based on `ResetTimeout`. Creates a default (Closed) state for new providers.
    - `RecordSuccess(providerName string)`: Resets consecutive failures. Transitions from HalfOpen to Closed on success.
    - `RecordFailure(providerName string)`: Increments consecutive failures. Transitions from Closed to Open if `FailureThreshold` is met. Transitions from HalfOpen back to Open on failure.
- Added `GetProviderStatus(providerName string) (State, int)` helper method for inspecting a provider's current state and failure count (useful for testing and potential monitoring).

`internal/router/circuitbreaker/circuitbreaker_test.go`:
- Created a comprehensive suite of unit tests for the `CircuitBreaker` service.
- Tested `NewCircuitBreaker` for default and custom configurations.
- Verified all state transitions: Closed -> Open, Open -> HalfOpen, HalfOpen -> Closed, HalfOpen -> Open.
- Tested scenarios where failures are below the threshold.
- Ensured independent state management for multiple providers.
- Confirmed correct handling of new/untracked providers (default to Closed).
- Tested `GetProviderStatus` and `State.String()`.

This service provides a foundational mechanism for improving system resilience by preventing repeated calls to failing providers.