### PR TITLE
feat: Integrate OpenTelemetry for distributed tracing

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -168,8 +168,8 @@ This `todo.md` tracks which implementation steps have been completed (☑) and w
 ## Chunk 16: Observability Integration
 
 24. **OpenTelemetry Tracing**  
-    - [ ] Add OTEL initialization in `cmd/server/main.go`, wrap Gin handlers with OTEL middleware.  
-    - [ ] Instrument `PlanBuilder.Build()`, `Orchestrator.Execute()`, `Router.ExecuteStep()` with spans (`Tracer.Start()` / `span.End()`).
+    - [☑] Add OTEL initialization in `cmd/server/main.go`, wrap Gin handlers with OTEL middleware.
+    - [☑] Instrument `PlanBuilder.Build()`, `Orchestrator.Execute()`, `Router.ExecuteStep()` with spans (`Tracer.Start()` / `span.End()`).
 
 25. **Prometheus Metrics**  
     - [ ] In `internal/planbuilder/planbuilder.go`, register and increment `plan_requests_total`, record `plan_build_duration_seconds`.  


### PR DESCRIPTION
This commit introduces OpenTelemetry to the payment orchestrator for enhanced observability.

Key changes:
- Initializes an OpenTelemetry tracer provider in `cmd/server/main.go` using a stdout exporter for local debugging.
- Registers the tracer provider globally and sets W3C Trace Context as the propagator.
- Adds OpenTelemetry middleware to the Gin router (`otelgin`) to automatically trace incoming HTTP requests.
- Instruments key methods with spans:
    - `PlanBuilder.Build()` in `internal/planbuilder/planbuilder.go`
    - `Orchestrator.Execute()` in `internal/orchestrator/orchestrator.go`
    - `Router.ExecuteStep()` and `Router.tryFallback()` in `internal/router/router.go`
- Updates `todo.md` to reflect the completion of the OpenTelemetry tracing task.

This integration will allow for better monitoring and debugging of request flows through the system.