### PR TITLE
feat: Implement ContractMonitor for JSON schema validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,9 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/crypto v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,12 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -1,0 +1,56 @@
+package monitor
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/xeipuuv/gojsonschema"
+)
+
+// ContractMonitor validates incoming requests against a JSON schema.
+type ContractMonitor struct {
+	schemaLoader gojsonschema.JSONLoader
+}
+
+// NewContractMonitor creates a new ContractMonitor with the given schema file path.
+// The schemaPath should be an absolute path or relative to the execution directory.
+func NewContractMonitor(schemaPath string) (*ContractMonitor, error) {
+	schemaLoader := gojsonschema.NewReferenceLoader("file://" + schemaPath)
+	// Check if schema is valid by trying to load it into a schema object
+	_, err := gojsonschema.NewSchema(schemaLoader)
+	if err != nil {
+		return nil, fmt.Errorf("error loading or compiling schema %s: %w", schemaPath, err)
+	}
+
+	return &ContractMonitor{
+		schemaLoader: schemaLoader,
+	}, nil
+}
+
+// Validate validates the given request body against the loaded JSON schema.
+// It returns true if valid, or false and a list of validation errors if invalid.
+func (cm *ContractMonitor) Validate(requestBody []byte) (bool, []string, error) {
+	documentLoader := gojsonschema.NewBytesLoader(requestBody)
+	result, err := gojsonschema.Validate(cm.schemaLoader, documentLoader)
+	if err != nil {
+		return false, nil, fmt.Errorf("error during validation: %w", err)
+	}
+
+	if result.Valid() {
+		return true, nil, nil
+	}
+
+	var errors []string
+	for _, desc := range result.Errors() {
+		errors = append(errors, desc.String())
+	}
+	return false, errors, nil
+}
+
+// FormatErrors formats a slice of validation error strings into a single string.
+func FormatErrors(validationErrors []string) string {
+	if len(validationErrors) == 0 {
+		return ""
+	}
+	return "Validation errors: " + strings.Join(validationErrors, "; ")
+}

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -1,0 +1,204 @@
+package monitor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewContractMonitor(t *testing.T) {
+	// Create a dummy schema file for testing
+	testSchemaContent := `{
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title": "TestSchema",
+		"type": "object",
+		"properties": { "name": { "type": "string" } },
+		"required": ["name"]
+	}`
+	schemaDir := t.TempDir()
+	schemaFile := filepath.Join(schemaDir, "test_schema.json")
+	if err := os.WriteFile(schemaFile, []byte(testSchemaContent), 0644); err != nil {
+		t.Fatalf("Failed to write test schema file: %v", err)
+	}
+
+	t.Run("SuccessfulLoad", func(t *testing.T) {
+		cm, err := NewContractMonitor(schemaFile)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if cm == nil {
+			t.Fatal("Expected ContractMonitor instance, got nil")
+		}
+		if cm.schemaLoader == nil {
+			t.Fatal("Expected schemaLoader to be initialized, got nil")
+		}
+	})
+
+	t.Run("SchemaFileNotFound", func(t *testing.T) {
+		_, err := NewContractMonitor("non_existent_schema.json")
+		if err == nil {
+			t.Fatal("Expected error for non-existent schema, got nil")
+		}
+		if !strings.Contains(err.Error(), "no such file or directory") && !strings.Contains(err.Error(), "cannot find the file") { // Error messages can vary
+			t.Errorf("Expected 'no such file or directory' or 'cannot find the file' in error, got: %v", err)
+		}
+	})
+
+	t.Run("InvalidSchemaSyntax", func(t *testing.T) {
+		invalidSchemaFile := filepath.Join(schemaDir, "invalid_schema.json")
+		if err := os.WriteFile(invalidSchemaFile, []byte("{invalid_json"), 0644); err != nil {
+			t.Fatalf("Failed to write invalid test schema file: %v", err)
+		}
+		_, err := NewContractMonitor(invalidSchemaFile)
+		if err == nil {
+			t.Fatal("Expected error for invalid schema syntax, got nil")
+		}
+	})
+}
+
+func TestContractMonitor_Validate(t *testing.T) {
+	// Use the testdata schema for these tests
+	// Construct path relative to current file to find testdata
+	// Note: This assumes 'go test' is run from the package directory or project root in a way that relative paths work.
+	// A more robust way in general might be to use runtime.Caller to get current file's dir.
+	// For now, direct relative path from where `go test` is typically run.
+	schemaPath := filepath.Join("testdata", "test_schema.json")
+
+	// Ensure the testdata directory and schema file exist
+	// The test_schema.json should have been created by a previous step or checked into VCS.
+	// This check is more for safety during test execution if testdata is gitignored or built dynamically.
+	// If the file `internal/monitor/testdata/test_schema.json` is guaranteed by a previous step,
+	// then explicit creation here might be redundant or could be simplified.
+	// For this specific subtask, the file is created in step 2.
+	// So, we can assume it exists. If not, NewContractMonitor will fail, which is part of the test.
+
+	cm, err := NewContractMonitor(schemaPath)
+	if err != nil {
+		// This could fail if test_schema.json wasn't created in the previous step as expected.
+		// Or if the path `testdata/test_schema.json` is not correct relative to test execution dir.
+		t.Fatalf("Failed to create ContractMonitor for validation tests (schema: %s): %v. Ensure testdata/test_schema.json exists.", schemaPath, err)
+	}
+
+	tests := []struct {
+		name          string
+		payload       string
+		expectValid   bool
+		expectErrors  bool // True if either validation errors OR functional error from Validate() is expected
+		errorContains []string
+	}{
+		{
+			name:        "ValidPayload",
+			payload:     `{"name": "John Doe", "age": 30, "email": "john.doe@example.com"}`,
+			expectValid: true,
+		},
+		{
+			name:          "InvalidPayload_MissingRequiredField",
+			payload:       `{"name": "Jane Doe"}`, // age is missing
+			expectValid:   false,
+			expectErrors:  true,
+			errorContains: []string{"age", "(root): age is required"}, // More specific error text
+		},
+		{
+			name:          "InvalidPayload_WrongType",
+			payload:       `{"name": "Test", "age": "thirty"}`, // age should be integer
+			expectValid:   false,
+			expectErrors:  true,
+			errorContains: []string{"age", "Invalid type. Expected: integer, given: string"},
+		},
+		{
+			name:          "InvalidPayload_FormatViolation",
+			payload:       `{"name": "Test", "age": 25, "email": "not-an-email"}`,
+			expectValid:   false,
+			expectErrors:  true,
+			errorContains: []string{"email", "Does not match format 'email'"},
+		},
+		{
+			name:        "InvalidPayload_AdditionalPropertyAllowed", // Corrected expectation
+			payload:     `{"name": "Test", "age": 25, "city": "New York"}`,
+			expectValid: true, // Schema allows additional properties by default
+		},
+		{
+			name:         "MalformedJSON",
+			payload:      `{"name": "Test", "age": 25,`,
+			expectValid:  false,
+			expectErrors: true, // Error comes from gojsonschema.Validate's internal JSON parsing
+			// errorContains: []string{"unexpected EOF"}, // Error message might vary
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valid, validationErrs, funcErr := cm.Validate([]byte(tt.payload))
+
+			if tt.expectErrors {
+				if funcErr == nil && len(validationErrs) == 0 {
+					t.Errorf("Expected errors, but got none (funcErr: %v, validationErrs: %v)", funcErr, validationErrs)
+				}
+			} else { // Expect no errors at all
+				if funcErr != nil {
+					t.Errorf("Expected no functional error, got %v", funcErr)
+				}
+				if len(validationErrs) > 0 {
+					t.Errorf("Expected no validation errors, got %v", validationErrs)
+				}
+			}
+
+			if valid != tt.expectValid {
+				t.Errorf("Expected valid=%v, got valid=%v. ValidationErrors: %v, FuncErr: %v", tt.expectValid, valid, validationErrs, funcErr)
+			}
+
+			if len(tt.errorContains) > 0 {
+				combinedErrors := ""
+				if len(validationErrs) > 0 {
+					combinedErrors = strings.Join(validationErrs, "; ")
+				}
+				if funcErr != nil { // include Validate's own error message if any
+					if combinedErrors != "" {
+						combinedErrors += "; "
+					}
+					combinedErrors += funcErr.Error()
+				}
+
+				for _, ec := range tt.errorContains {
+					if !strings.Contains(combinedErrors, ec) {
+						t.Errorf("Expected errors to contain '%s', but got: %s", ec, combinedErrors)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestFormatErrors(t *testing.T) {
+	tests := []struct {
+		name           string
+		errors         []string
+		expectedOutput string
+	}{
+		{
+			name:           "NoErrors",
+			errors:         []string{},
+			expectedOutput: "",
+		},
+		{
+			name:           "SingleError",
+			errors:         []string{"Error: Field 'X' is required."},
+			expectedOutput: "Validation errors: Error: Field 'X' is required.",
+		},
+		{
+			name:           "MultipleErrors",
+			errors:         []string{"Error 1", "Error 2"},
+			expectedOutput: "Validation errors: Error 1; Error 2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := FormatErrors(tt.errors)
+			if output != tt.expectedOutput {
+				t.Errorf("Expected '%s', got '%s'", tt.expectedOutput, output)
+			}
+		})
+	}
+}

--- a/internal/monitor/testdata/test_schema.json
+++ b/internal/monitor/testdata/test_schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TestSchema",
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "age": { "type": "integer", "minimum": 0 },
+    "email": { "type": "string", "format": "email" }
+  },
+  "required": ["name", "age"]
+}

--- a/schemas/external_request_schema.json
+++ b/schemas/external_request_schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ExternalRequest",
+  "description": "Schema for an external payment request",
+  "type": "object",
+  "properties": {
+    "request_id": {
+      "type": "string",
+      "description": "Unique identifier for the request"
+    },
+    "merchant_id": {
+      "type": "string",
+      "description": "Identifier for the merchant"
+    },
+    "amount": {
+      "type": "integer",
+      "description": "Payment amount in the smallest currency unit (e.g., cents)"
+    },
+    "currency": {
+      "type": "string",
+      "description": "3-letter ISO currency code"
+    },
+    "customer": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "email": { "type": "string", "format": "email" },
+        "phone": { "type": "string" }
+      },
+      "required": ["name", "email"]
+    },
+    "payment_method": {
+      "type": "object",
+      "oneOf": [
+        {
+          "properties": {
+            "card": {
+              "type": "object",
+              "properties": {
+                "card_number": { "type": "string" },
+                "expiry_month": { "type": "string" },
+                "expiry_year": { "type": "string" },
+                "cvv": { "type": "string" }
+              },
+              "required": ["card_number", "expiry_month", "expiry_year", "cvv"]
+            }
+          },
+          "required": ["card"]
+        },
+        {
+          "properties": {
+            "wallet": {
+              "type": "object",
+              "properties": {
+                "wallet_type": { "type": "string" },
+                "token": { "type": "string" }
+              },
+              "required": ["wallet_type", "token"]
+            }
+          },
+          "required": ["wallet"]
+        }
+      ]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "request_id",
+    "merchant_id",
+    "amount",
+    "currency",
+    "customer",
+    "payment_method"
+  ]
+}

--- a/todo.md
+++ b/todo.md
@@ -180,8 +180,8 @@ This `todo.md` tracks which implementation steps have been completed (☑) and w
 ## Chunk 17: ContractMonitor & RetrospectiveReporter
 
 26. **ContractMonitor**  
-    - [ ] Create `internal/monitor/monitor.go` using `gojsonschema` to validate incoming JSON messages against a schema.  
-    - [ ] Write tests in `internal/monitor/monitor_test.go` simulating valid and invalid JSON.  
+    - [☑] Create `internal/monitor/monitor.go` using `gojsonschema` to validate incoming JSON messages against a schema.
+    - [☑] Write tests in `internal/monitor/monitor_test.go` simulating valid and invalid JSON.
 
 27. **RetrospectiveReporter**  
     - [ ] Create `internal/reporting/retrospective.go` with `GenerateRetrospective(logs []LogEntry)`.  


### PR DESCRIPTION
This commit introduces a ContractMonitor component responsible for validating incoming JSON request payloads against a predefined JSON schema. This helps ensure data integrity and contract adherence early in the request lifecycle.

Key changes:
- Created `schemas/external_request_schema.json` which defines the expected structure for incoming payment requests, based on the `ExternalRequest` protobuf message.
- Implemented `internal/monitor/monitor.go` containing:
    - `ContractMonitor` struct that loads and holds a JSON schema.
    - `NewContractMonitor(schemaPath string)` function to initialize the monitor with a schema from a given file path.
    - `Validate(requestBody []byte)` method to validate a byte slice (request body) against the loaded schema using the `gojsonschema` library.
    - `FormatErrors` helper function to pretty-print validation errors.
- Added `gojsonschema` as a project dependency.
- Implemented comprehensive tests in `internal/monitor/monitor_test.go`:
    - Tests for `NewContractMonitor` covering successful loading, file-not-found errors, and invalid schema syntax.
    - Tests for the `Validate` method with various valid and invalid JSON payloads, checking different failure modes (missing fields, type mismatches, format violations).
    - A `testdata/test_schema.json` was created for use in these tests.
- Updated `todo.md` to mark task 26 (ContractMonitor) as complete.

This component can be integrated into the API layer to validate requests before further processing.